### PR TITLE
feat(backend,cdk): add AppStack and support multi-target Docker builds for api/chat/ingest Lambdas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install dev dev-frontend dev-backend lint format test docker-build docker-up docker-down
+.PHONY: install dev dev-frontend dev-backend lint format test docker-build docker-build-worker docker-up docker-down
 
 install: ## Install frontend + backend dependencies
 	cd apps/frontend && npm install
@@ -26,8 +26,11 @@ format:
 test:
 	cd apps/backend && uv run pytest
 
-docker-build: ## Build the Lambda-deployable backend image
+docker-build: ## Build the Lambda-deployable backend image (web target)
 	docker compose build backend
+
+docker-build-worker: ## Build the ingest-fn (worker target) image
+	docker build --target worker -t event-driven-rag-backend-worker apps/backend
 
 docker-up: ## Run the backend image on :8000 (stop the native backend first)
 	docker compose up --build backend

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,9 +1,12 @@
 # syntax=docker/dockerfile:1
-# Single FastAPI image deployed to three Lambdas (api-fn / chat-fn / ingest-fn).
-# - api-fn / chat-fn: Lambda Web Adapter (extension below) + this CMD.
-# - chat-fn: CDK sets AWS_LWA_INVOKE_MODE=response_stream for SSE.
-# - ingest-fn: CDK overrides CMD to a plain Lambda handler (no adapter).
-# Locally the same image runs as a plain HTTP server: the extension is inert
+# Single FastAPI codebase deployed to three Lambdas (api-fn / chat-fn / ingest-fn).
+# One shared builder, two final targets (CDK selects the target per function):
+# - web:    api-fn / chat-fn. Lambda Web Adapter extension + uvicorn CMD.
+#           chat-fn: CDK sets AWS_LWA_INVOKE_MODE=response_stream for SSE.
+# - worker: ingest-fn. Plain Lambda handler via awslambdaric — no adapter.
+#           (The adapter extension has no disable flag and would block init
+#           waiting for a web server that never starts.)
+# Locally the web target runs as a plain HTTP server: the extension is inert
 # outside the Lambda runtime.
 
 FROM public.ecr.aws/docker/library/python:3.12-slim AS builder
@@ -20,7 +23,13 @@ COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
-FROM public.ecr.aws/docker/library/python:3.12-slim
+# Adds awslambdaric on top of the shared venv (worker group only)
+FROM builder AS worker-builder
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project --group worker
+
+# ---- web: api-fn / chat-fn (Lambda Web Adapter + uvicorn) ----
+FROM public.ecr.aws/docker/library/python:3.12-slim AS web
 
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1 /lambda-adapter /opt/extensions/lambda-adapter
 
@@ -38,3 +47,15 @@ EXPOSE 8000
 
 # Each Lambda sandbox serves one request at a time; a single worker suffices.
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# ---- worker: ingest-fn (no adapter; runtime interface client) ----
+FROM public.ecr.aws/docker/library/python:3.12-slim AS worker
+
+WORKDIR /app
+COPY --from=worker-builder /app/.venv ./.venv
+COPY app ./app
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+ENTRYPOINT ["/app/.venv/bin/python", "-m", "awslambdaric"]
+CMD ["app.ingest_handler.handler"]

--- a/apps/backend/app/ingest_handler.py
+++ b/apps/backend/app/ingest_handler.py
@@ -1,0 +1,22 @@
+"""ingest-fn entrypoint, invoked by awslambdaric (Dockerfile worker target).
+
+Runs as a plain Lambda handler triggered by SQS — no Web Adapter, no FastAPI.
+Text extraction / chunking / embedding / S3 Vectors registration will be
+implemented in a later issue; for now the handler only logs received messages.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+# The Lambda runtime already attaches a handler to the root logger, so
+# logging.basicConfig() is a no-op here; set the level directly instead.
+logger.setLevel(logging.INFO)
+
+
+def handler(event, context):
+    records = event.get("Records", [])
+    logger.info("received %d ingest message(s)", len(records))
+    for record in records:
+        logger.info("messageId=%s body=%s", record.get("messageId"), record.get("body"))
+    # Partial-batch response shape; empty means every record succeeded.
+    return {"batchItemFailures": []}

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -19,6 +19,10 @@ dev = [
     "pytest>=9.1.1",
     "ruff>=0.15.22",
 ]
+# ingest-fn(Dockerfileのworkerターゲット)専用。ネイティブ開発環境には入れない
+worker = [
+    "awslambdaric>=3.1",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -34,6 +34,30 @@ wheels = [
 ]
 
 [[package]]
+name = "awslambdaric"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simplejson" },
+    { name = "snapshot-restore-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/00/cb7eb5d32b0fb04be9b09b512f8e2d4729dbf10cdea3e75f139fe405b7bc/awslambdaric-4.0.1.tar.gz", hash = "sha256:6559779b59f39426026557f4bd8fa90fa4b3dcf5965d230362eb4a83ec4f81d2", size = 4503813, upload-time = "2026-06-26T14:21:30.708Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/2b/a5e6c2ca4795e8fbc00ed1471910b1cdd441af1233c3a466299ce79be550/awslambdaric-4.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0445e74f5ca1356f92a861cee55d539d3d976569524c8a5bf1e6718c24a70ff6", size = 345877, upload-time = "2026-06-26T14:22:53.648Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c6/b6644ed1cba744c4183d5e2fc0c376b20e9166fdcbf5f081dccff882a4af/awslambdaric-4.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9ee8329fb5e08399fb89531eae729d750b687c67acad03489c8798a571d5869b", size = 348527, upload-time = "2026-06-26T14:21:20.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/9e/29a61c2b5cf797a1208dd8d0aaf398aaf7ac370bbe63a700ae236a479a7d/awslambdaric-4.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:333c108954480df0f0019d6b78b41624d2fbc8f806b223e619dda759f2e9da1b", size = 345866, upload-time = "2026-06-26T14:22:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2d/0bb5330c1b8f5bd111d24edfa8f86003814cb5b3798a6cd7fec07a780587/awslambdaric-4.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe88e8677dbef80d9f78287d58c726ea84659040b92fcbcf071efda8f97c9036", size = 348539, upload-time = "2026-06-26T14:21:21.314Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b7/f3e77510de900d587134fa8757c5efec27ce79f3427dafb1766110c03617/awslambdaric-4.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0ba8f9827add7b2fa6821697ddd83a2170fb584226981f82641a2b62b302bdbc", size = 346126, upload-time = "2026-06-26T14:22:56.479Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/40/8475d594bd73acbed8effbc040cd1516234d17717d53adb41f57d0e502c0/awslambdaric-4.0.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e3e7418633a67a5648bed7e086e3733cdf03b8a16c2d5e52ee2a8f25bd9c943", size = 348667, upload-time = "2026-06-26T14:21:22.824Z" },
+    { url = "https://files.pythonhosted.org/packages/af/65/ccfc99586e3c1f9388dcb1b95951b8d6be016ee03cebb8a5c070d095b754/awslambdaric-4.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90aa1f1c1c58a67ca1b87d9f7dbedde73724b8546d18e1011c8fe74bb0ac1f43", size = 347791, upload-time = "2026-06-26T14:22:57.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/b3214be854b71a877d3b88a75b37746ebd314cb70e099eb8bb9408ac1f65/awslambdaric-4.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6bbacaa19a5e0ba097a524e14ba2b80023497ea839e0fdb3e8875e3b44817618", size = 350069, upload-time = "2026-06-26T14:21:24.266Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4c/79382868664511625db74dac424ce2939cfab50c12faa54b4d25092159ee/awslambdaric-4.0.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b19e2472765f9db0c3c9ea6cdaa201fc3f361c15de98e41f7ef0908205aa8b5c", size = 346646, upload-time = "2026-06-26T14:22:58.964Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d8/2aa3fa705677699510a3475dc4767f520119d0e50808feb7e4bdda260e80/awslambdaric-4.0.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:60545730bace404c54933d3e990cbecc257b236bcb4ea742af38be3ba052c425", size = 350041, upload-time = "2026-06-26T14:21:25.592Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9d/793358ccf85b68461e14dc2fb798bd61e6e9e03a34a75e4c5536b916c58f/awslambdaric-4.0.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d68546c0b09cfca12978af453be7e60bc713817b869139fb0b40f57462fd1790", size = 348177, upload-time = "2026-06-26T14:23:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/74/e159dcd7ad1cf2548b5002172d08ada2e9d5b9ae35580014631cfc61e81b/awslambdaric-4.0.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:908cc86c6395d20c7c85b93dfdb7bdc3db0dc84dd0c3a78ea4a209b7d6afebb7", size = 351327, upload-time = "2026-06-26T14:21:26.843Z" },
+]
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
@@ -52,6 +76,9 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+worker = [
+    { name = "awslambdaric" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -69,6 +96,7 @@ dev = [
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.22" },
 ]
+worker = [{ name = "awslambdaric", specifier = ">=3.1" }]
 
 [[package]]
 name = "boto3"
@@ -429,12 +457,74 @@ wheels = [
 ]
 
 [[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/25/e90998fe8e480eb43b966c09e835379887d427567ebd496563d3b1e16b19/simplejson-4.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:19040a17154dc03d289bab68d73ce0a6a0be01de30c584bbdd93490bead14b22", size = 112414, upload-time = "2026-04-24T19:23:06.084Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a0/abd4785f36c3400f1fbb21f517be39295a750a714f04b7ee175adf6ef580/simplejson-4.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a94ebaecdbaa80d9551a3ec6bf0c9302fc8b53ab6c1b2bfd498a1df4cb28158d", size = 91120, upload-time = "2026-04-24T19:23:07.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/78/fc060d2e3b13c6ec59288574b8efac64075e316b2afba4396a56b2422f78/simplejson-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:67341c95c0a168ab4a6d1e807e50463f1c8da932c3286d81e201266c427061fa", size = 91055, upload-time = "2026-04-24T19:23:09.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45ec18e337fec538b7e902d489505c450b2454653d1290f3f50385e6fd8aa607", size = 190297, upload-time = "2026-04-24T19:23:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1c/e4d0eab695be3eb21d0f46bce820752031f03e7113f9c80a9b3c73ee7157/simplejson-4.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:820c69a4710400e9b248d5670647d60be58824369282d3925e516b3ff1a7cd82", size = 187002, upload-time = "2026-04-24T19:23:12.982Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0e/7f5a59d29426b062d5928fb88b403c3f797129d53be7102f955dbe51aa44/simplejson-4.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e708d373a10e4378ef2d59f8361850c7150fd907ed49efe49bc5492160476d1", size = 195146, upload-time = "2026-04-24T19:23:14.517Z" },
+    { url = "https://files.pythonhosted.org/packages/78/18/9943db224dd4d5fa3c090c3e56a94c37b254338c83995ec5680285111c40/simplejson-4.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:980fc33353f81fd12d8c49d44f8c2760d1dc8192285e627c5180d141035b228a", size = 183931, upload-time = "2026-04-24T19:23:16.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/9a690da9a766161c06c627d805362cf159f1abe480969372b2897649b955/simplejson-4.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de2ed102fff88dacf543699f53ee3a533cc11539a39baa176b7e09dd783069d6", size = 192228, upload-time = "2026-04-24T19:23:18.33Z" },
+    { url = "https://files.pythonhosted.org/packages/05/88/bd8aad36b451ffb0e0a3f721d695a88befa6d1ac7d1e02ae788ca7ff4029/simplejson-4.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785ff8edc0e28bf773a32543a6bbed46351453c997b3f6709c744e3c2f7eabb", size = 187808, upload-time = "2026-04-24T19:23:21.165Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ee/14f91db0d1f481533b651dafbf8cd0da088d9817f7af30c68f7f19f9c847/simplejson-4.1.1-cp312-cp312-win32.whl", hash = "sha256:2e0d5ead6d14610467ec356ec1f6b5d8a56aa216abaad8d41c8b873b16cf313f", size = 88512, upload-time = "2026-04-24T19:23:22.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c4/90de06b2d8737c68c05ff9274113f854dbf6a5f28b7a955212111672cb57/simplejson-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:63a5451f557d6be48a231bae932458655c620902b868170b2f1c8afed496f6b4", size = 90748, upload-time = "2026-04-24T19:23:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/47b445eeb559c9593453a0648e0fd6d08e8adff64dd5e5ced66726da8a09/simplejson-4.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dff52fc7af272e84fc21cc5a06c927c823ca6ae00af14f3b0d7707b42775ed98", size = 113160, upload-time = "2026-04-24T19:23:26.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/cb72db31523c164dea5dc55b02dad065a40c478856bc7534b279d2b51906/simplejson-4.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:971aed0647ad6e840a3943bec812fcda5f2d26a5497a4981d1fb49aa4f9a396c", size = 91521, upload-time = "2026-04-24T19:23:27.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e5/54cb7c50ad5fdc1e0a86b7df4b135c2cbd5c4623605aa94466659098e8da/simplejson-4.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:249e2e220aa6d9b9d936bde84eb7bf79d5b6c5a8273c6e411f8b1635a9073f2d", size = 91407, upload-time = "2026-04-24T19:23:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/21a3ede87f0bf82d6c7bcb90480d50a6490eb974c6ab20881188e440957c/simplejson-4.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e5cdd6a5d52299f345c15ab5678cc4249e24f383f361d986afbc3c7072a6b6b", size = 192451, upload-time = "2026-04-24T19:23:30.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/9903edd3102bf0b5984edfcb90c88612330996efa3b4fbf8a971d6e17839/simplejson-4.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642cec364e0676e2d5a73fa4d31d0c7c55886997caa2fde24e8292ca44d32728", size = 189015, upload-time = "2026-04-24T19:23:32.647Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cd/33230927a780e1398b857e3944abb914556994d252b1d765ae40d112cb25/simplejson-4.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:76fe296ca1df23d290033f10aaacf534fd1b3e3007e7f9ff8aa68b21413aaa78", size = 196658, upload-time = "2026-04-24T19:23:34.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/2c5a7444eb53e9a86d3738299bffddd9f53aeed799ded2f45368221fdb19/simplejson-4.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f0ad25b7dc4e0fb23858355819f2e994f1a5badcdcde8737eac7921c2f1ed2a", size = 185967, upload-time = "2026-04-24T19:23:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/454378e06d059cd412a7ed5d87fb6d29fd5b60f13a4d89fc1f764ff434df/simplejson-4.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a59ebd0533f03fd06ff0c42ba0f02d93cbcdd7944922bf3b93911327a95b901f", size = 193940, upload-time = "2026-04-24T19:23:38.151Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d5/a15bf915f623a2c5a079d6e3be8256fdb8ef06f110669493a09b9d6933e0/simplejson-4.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bccbf4419676b517939852e5aeff2af6aee4dc046881c67a1581fa6f1cb01abd", size = 189795, upload-time = "2026-04-24T19:23:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/37212ae7dc4b607f0978c408e8633f05c810884e054c33113184c6c2c8a2/simplejson-4.1.1-cp313-cp313-win32.whl", hash = "sha256:6c845363eb5fd166fb7c72243da38f4fcfde666ede7fdf2cc6fd7762894626f7", size = 88773, upload-time = "2026-04-24T19:23:41.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c7a0a47883a9015b54c9d8a4b62f2aba17bd4335b1787b9b8a0fc2fa6d52/simplejson-4.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:104d8324c34f25b4b90800bc5fa363780cbc3d8496aef061cba7ce1af9162270", size = 90888, upload-time = "2026-04-24T19:23:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snapshot-restore-py"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/19/2d7584749a7f6d1b4b3a129995b1bc31e70ed9c5ecc323f1ee748b767268/snapshot-restore-py-1.0.0.tar.gz", hash = "sha256:4d27f82fb6f09968f422501e9c3c2dea48a46cd19dc798eb7d6cbc57523c8004", size = 3379, upload-time = "2024-11-13T14:40:22.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/b8/f9da2457e9dfb5872042202d69b329940527672e20cbfdb26610c09e1d8e/snapshot_restore_py-1.0.0-py3-none-any.whl", hash = "sha256:38f99e696793790f54658e71c68c7a8a40cea877c81232b5052383b1301aceba", size = 3782, upload-time = "2024-11-13T14:40:21.33Z" },
 ]
 
 [[package]]

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib/core';
+import { AppStack } from '../lib/app-stack';
 import { DataStack } from '../lib/data-stack';
 
 const app = new cdk.App();
 
-new DataStack(app, 'DataStack', {
-  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-});
+const env = { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION };
+
+const dataStack = new DataStack(app, 'DataStack', { env });
+
+new AppStack(app, 'AppStack', { env, dataStack });

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -1,0 +1,173 @@
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib/core';
+import { Construct } from 'constructs';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { DataStack } from './data-stack';
+
+// SecureStringはCloudFormationで作成できないため、パラメータ本体は手動作成する
+// (手順はcdk/README.md参照)。CDKは名前参照で読み取り権限のみ付与し、
+// Lambdaへはパラメータ名を環境変数で渡す(値は渡さない)。ADR-0008参照。
+export const OPENAI_API_KEY_PARAMETER_NAME = '/event-driven-rag/openai-api-key';
+export const COHERE_API_KEY_PARAMETER_NAME = '/event-driven-rag/cohere-api-key';
+
+export interface AppStackProps extends cdk.StackProps {
+  dataStack: DataStack;
+}
+
+/**
+ * アプリケーション層スタック。
+ * 単一のbackendコードベースを責務別に3つのコンテナLambda
+ * (api-fn / chat-fn / ingest-fn)としてデプロイする(ADR-0003)。
+ */
+export class AppStack extends cdk.Stack {
+  public readonly repository: ecr.Repository;
+  public readonly apiFunction: lambda.DockerImageFunction;
+  public readonly chatFunction: lambda.DockerImageFunction;
+  public readonly ingestFunction: lambda.DockerImageFunction;
+  public readonly apiFunctionUrl: lambda.FunctionUrl;
+  public readonly chatFunctionUrl: lambda.FunctionUrl;
+
+  constructor(scope: Construct, id: string, props: AppStackProps) {
+    super(scope, id, props);
+
+    const { dataStack } = props;
+
+    // CI/CD用の常設リポジトリ(CIが build → push → update-function-code で使う)。
+    // 現時点のLambdaは下のイメージアセット(bootstrapのアセットリポジトリ)を参照する
+    this.repository = new ecr.Repository(this, 'Repository', {
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      emptyOnDelete: true,
+    });
+
+    const backendPath = path.join(__dirname, '..', '..', 'apps', 'backend');
+    // web: Lambda Web Adapter + uvicorn(api-fn / chat-fn)
+    const webImage = lambda.DockerImageCode.fromImageAsset(backendPath, {
+      target: 'web',
+      platform: Platform.LINUX_AMD64,
+    });
+    // worker: awslambdaricによるプレーンハンドラ(ingest-fn)
+    const workerImage = lambda.DockerImageCode.fromImageAsset(backendPath, {
+      target: 'worker',
+      platform: Platform.LINUX_AMD64,
+    });
+
+    const openaiApiKeyParameter = ssm.StringParameter.fromSecureStringParameterAttributes(
+      this,
+      'OpenaiApiKeyParameter',
+      { parameterName: OPENAI_API_KEY_PARAMETER_NAME },
+    );
+    const cohereApiKeyParameter = ssm.StringParameter.fromSecureStringParameterAttributes(
+      this,
+      'CohereApiKeyParameter',
+      { parameterName: COHERE_API_KEY_PARAMETER_NAME },
+    );
+
+    // REST API(認証、一覧、presigned URL発行、取込開始のSQS送信)
+    this.apiFunction = new lambda.DockerImageFunction(this, 'ApiFunction', {
+      code: webImage,
+      memorySize: 512,
+      timeout: cdk.Duration.seconds(30),
+      environment: {
+        TABLE_NAME: dataStack.table.tableName,
+        DOCUMENTS_BUCKET_NAME: dataStack.documentsBucket.bucketName,
+        INGEST_QUEUE_URL: dataStack.ingestQueue.queueUrl,
+        POWERTOOLS_SERVICE_NAME: 'api',
+        POWERTOOLS_LOG_LEVEL: 'INFO',
+      },
+    });
+
+    // TODO: EdgeStack実装時にAWS_IAM + CloudFront OACへ切り替える
+    this.apiFunctionUrl = this.apiFunction.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+    });
+
+    dataStack.table.grantReadWriteData(this.apiFunction);
+    // presigned URLはLambdaロールの権限で署名されるため、発行対象の操作権限が必要
+    dataStack.documentsBucket.grantReadWrite(this.apiFunction);
+    dataStack.ingestQueue.grantSendMessages(this.apiFunction);
+
+    // LangGraph Self-RAGによるSSEストリーミングチャット
+    this.chatFunction = new lambda.DockerImageFunction(this, 'ChatFunction', {
+      code: webImage,
+      memorySize: 1024,
+      timeout: cdk.Duration.seconds(300),
+      environment: {
+        TABLE_NAME: dataStack.table.tableName,
+        VECTOR_BUCKET_ARN: dataStack.vectorBucket.attrVectorBucketArn,
+        VECTOR_INDEX_ARN: dataStack.vectorIndex.attrIndexArn,
+        OPENAI_API_KEY_PARAMETER_NAME,
+        COHERE_API_KEY_PARAMETER_NAME,
+        // Function URLのRESPONSE_STREAMとセットで必要(片方だけだとバッファリングされる)
+        AWS_LWA_INVOKE_MODE: 'response_stream',
+        POWERTOOLS_SERVICE_NAME: 'chat',
+        POWERTOOLS_LOG_LEVEL: 'INFO',
+      },
+    });
+
+    // TODO: EdgeStack実装時にAWS_IAM + CloudFront OACへ切り替える
+    this.chatFunctionUrl = this.chatFunction.addFunctionUrl({
+      authType: lambda.FunctionUrlAuthType.NONE,
+      invokeMode: lambda.InvokeMode.RESPONSE_STREAM,
+    });
+
+    dataStack.table.grantReadWriteData(this.chatFunction);
+    this.chatFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['s3vectors:GetIndex', 's3vectors:QueryVectors', 's3vectors:GetVectors'],
+        resources: [dataStack.vectorIndex.attrIndexArn],
+      }),
+    );
+    openaiApiKeyParameter.grantRead(this.chatFunction);
+    cohereApiKeyParameter.grantRead(this.chatFunction);
+
+    // テキスト抽出 → チャンク分割 → embedding → S3 Vectors登録(SQSトリガー)
+    this.ingestFunction = new lambda.DockerImageFunction(this, 'IngestFunction', {
+      code: workerImage,
+      memorySize: 1024,
+      // SQSの可視性タイムアウト900秒以内に収める
+      timeout: cdk.Duration.seconds(600),
+      environment: {
+        TABLE_NAME: dataStack.table.tableName,
+        DOCUMENTS_BUCKET_NAME: dataStack.documentsBucket.bucketName,
+        VECTOR_BUCKET_ARN: dataStack.vectorBucket.attrVectorBucketArn,
+        VECTOR_INDEX_ARN: dataStack.vectorIndex.attrIndexArn,
+        OPENAI_API_KEY_PARAMETER_NAME,
+        POWERTOOLS_SERVICE_NAME: 'ingest',
+        POWERTOOLS_LOG_LEVEL: 'INFO',
+      },
+    });
+
+    // 1ドキュメントの処理が長いため1メッセージずつ起動する
+    this.ingestFunction.addEventSource(
+      new SqsEventSource(dataStack.ingestQueue, { batchSize: 1 }),
+    );
+
+    dataStack.table.grantReadWriteData(this.ingestFunction);
+    dataStack.documentsBucket.grantRead(this.ingestFunction);
+    this.ingestFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: [
+          's3vectors:GetIndex',
+          's3vectors:PutVectors',
+          // 再取込時の既存ベクトル削除用
+          's3vectors:ListVectors',
+          's3vectors:DeleteVectors',
+        ],
+        resources: [dataStack.vectorIndex.attrIndexArn],
+      }),
+    );
+    openaiApiKeyParameter.grantRead(this.ingestFunction);
+
+    new cdk.CfnOutput(this, 'ApiFunctionUrl', { value: this.apiFunctionUrl.url });
+    new cdk.CfnOutput(this, 'ChatFunctionUrl', { value: this.chatFunctionUrl.url });
+    new cdk.CfnOutput(this, 'EcrRepositoryUri', { value: this.repository.repositoryUri });
+    new cdk.CfnOutput(this, 'ApiFunctionName', { value: this.apiFunction.functionName });
+    new cdk.CfnOutput(this, 'ChatFunctionName', { value: this.chatFunction.functionName });
+    new cdk.CfnOutput(this, 'IngestFunctionName', { value: this.ingestFunction.functionName });
+  }
+}

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -1,0 +1,839 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`スナップショット 1`] = `
+{
+  "Outputs": {
+    "ApiFunctionName": {
+      "Value": {
+        "Ref": "ApiFunctionCE271BD4",
+      },
+    },
+    "ApiFunctionUrl": {
+      "Value": {
+        "Fn::GetAtt": [
+          "ApiFunctionFunctionUrl73AD62DC",
+          "FunctionUrl",
+        ],
+      },
+    },
+    "ChatFunctionName": {
+      "Value": {
+        "Ref": "ChatFunction3D7C447E",
+      },
+    },
+    "ChatFunctionUrl": {
+      "Value": {
+        "Fn::GetAtt": [
+          "ChatFunctionFunctionUrl85FDC611",
+          "FunctionUrl",
+        ],
+      },
+    },
+    "EcrRepositoryUri": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            {
+              "Fn::Select": [
+                4,
+                {
+                  "Fn::Split": [
+                    ":",
+                    {
+                      "Fn::GetAtt": [
+                        "Repository22E53BBD",
+                        "Arn",
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            ".dkr.ecr.",
+            {
+              "Fn::Select": [
+                3,
+                {
+                  "Fn::Split": [
+                    ":",
+                    {
+                      "Fn::GetAtt": [
+                        "Repository22E53BBD",
+                        "Arn",
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "Repository22E53BBD",
+            },
+          ],
+        ],
+      },
+    },
+    "IngestFunctionName": {
+      "Value": {
+        "Ref": "IngestFunction4B2F2EB2",
+      },
+    },
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiFunctionCE271BD4": {
+      "DependsOn": [
+        "ApiFunctionServiceRoleDefaultPolicy20A32B8D",
+        "ApiFunctionServiceRole52B9747B",
+      ],
+      "Properties": {
+        "Code": {
+          "ImageUri": {
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0779c2020920be03ceec7397b58d0ae3ba7aa564151827f402e96796a723d3f3",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "DOCUMENTS_BUCKET_NAME": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputRefDocumentsBucket9EC9DEB9131399C0",
+            },
+            "INGEST_QUEUE_URL": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputRefIngestQueue2280FF4EF5DFF735",
+            },
+            "POWERTOOLS_LOG_LEVEL": "INFO",
+            "POWERTOOLS_SERVICE_NAME": "api",
+            "TABLE_NAME": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputRefTableCD117FA1D18A8047",
+            },
+          },
+        },
+        "MemorySize": 512,
+        "PackageType": "Image",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiFunctionServiceRole52B9747B",
+            "Arn",
+          ],
+        },
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiFunctionFunctionUrl73AD62DC": {
+      "Properties": {
+        "AuthType": "NONE",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "ApiFunctionCE271BD4",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Url",
+    },
+    "ApiFunctionServiceRole52B9747B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiFunctionServiceRoleDefaultPolicy20A32B8D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttDocumentsBucket9EC9DEB9ArnEA5095A7",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttDocumentsBucket9EC9DEB9ArnEA5095A7",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttIngestQueue2280FF4EArnFE0694A6",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiFunctionServiceRoleDefaultPolicy20A32B8D",
+        "Roles": [
+          {
+            "Ref": "ApiFunctionServiceRole52B9747B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiFunctioninvokefunctionB5A175E4": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiFunctionCE271BD4",
+            "Arn",
+          ],
+        },
+        "InvokedViaFunctionUrl": true,
+        "Principal": "*",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ApiFunctioninvokefunctionurl0B8A0798": {
+      "Properties": {
+        "Action": "lambda:InvokeFunctionUrl",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ApiFunctionCE271BD4",
+            "Arn",
+          ],
+        },
+        "FunctionUrlAuthType": "NONE",
+        "Principal": "*",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ChatFunction3D7C447E": {
+      "DependsOn": [
+        "ChatFunctionServiceRoleDefaultPolicy8AB4563A",
+        "ChatFunctionServiceRole544D50A9",
+      ],
+      "Properties": {
+        "Code": {
+          "ImageUri": {
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:0779c2020920be03ceec7397b58d0ae3ba7aa564151827f402e96796a723d3f3",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "AWS_LWA_INVOKE_MODE": "response_stream",
+            "COHERE_API_KEY_PARAMETER_NAME": "/event-driven-rag/cohere-api-key",
+            "OPENAI_API_KEY_PARAMETER_NAME": "/event-driven-rag/openai-api-key",
+            "POWERTOOLS_LOG_LEVEL": "INFO",
+            "POWERTOOLS_SERVICE_NAME": "chat",
+            "TABLE_NAME": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputRefTableCD117FA1D18A8047",
+            },
+            "VECTOR_BUCKET_ARN": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttVectorBucketVectorBucketArnAA1E2656",
+            },
+            "VECTOR_INDEX_ARN": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttVectorIndexIndexArnC883517D",
+            },
+          },
+        },
+        "MemorySize": 1024,
+        "PackageType": "Image",
+        "Role": {
+          "Fn::GetAtt": [
+            "ChatFunctionServiceRole544D50A9",
+            "Arn",
+          ],
+        },
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ChatFunctionFunctionUrl85FDC611": {
+      "Properties": {
+        "AuthType": "NONE",
+        "InvokeMode": "RESPONSE_STREAM",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "ChatFunction3D7C447E",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Url",
+    },
+    "ChatFunctionServiceRole544D50A9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ChatFunctionServiceRoleDefaultPolicy8AB4563A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3vectors:GetIndex",
+                "s3vectors:QueryVectors",
+                "s3vectors:GetVectors",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttVectorIndexIndexArnC883517D",
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/event-driven-rag/openai-api-key",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/event-driven-rag/cohere-api-key",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ChatFunctionServiceRoleDefaultPolicy8AB4563A",
+        "Roles": [
+          {
+            "Ref": "ChatFunctionServiceRole544D50A9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ChatFunctioninvokefunctionE31317E4": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ChatFunction3D7C447E",
+            "Arn",
+          ],
+        },
+        "InvokedViaFunctionUrl": true,
+        "Principal": "*",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ChatFunctioninvokefunctionurlE2D45C7F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunctionUrl",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "ChatFunction3D7C447E",
+            "Arn",
+          ],
+        },
+        "FunctionUrlAuthType": "NONE",
+        "Principal": "*",
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "IngestFunction4B2F2EB2": {
+      "DependsOn": [
+        "IngestFunctionServiceRoleDefaultPolicy8EB1E4A7",
+        "IngestFunctionServiceRole55EB4427",
+      ],
+      "Properties": {
+        "Code": {
+          "ImageUri": {
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:2ee5b87d59a6c32c3111f1841313e3fb33066775ed1b8469f86b1cf5e42baaba",
+          },
+        },
+        "Environment": {
+          "Variables": {
+            "DOCUMENTS_BUCKET_NAME": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputRefDocumentsBucket9EC9DEB9131399C0",
+            },
+            "OPENAI_API_KEY_PARAMETER_NAME": "/event-driven-rag/openai-api-key",
+            "POWERTOOLS_LOG_LEVEL": "INFO",
+            "POWERTOOLS_SERVICE_NAME": "ingest",
+            "TABLE_NAME": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputRefTableCD117FA1D18A8047",
+            },
+            "VECTOR_BUCKET_ARN": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttVectorBucketVectorBucketArnAA1E2656",
+            },
+            "VECTOR_INDEX_ARN": {
+              "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttVectorIndexIndexArnC883517D",
+            },
+          },
+        },
+        "MemorySize": 1024,
+        "PackageType": "Image",
+        "Role": {
+          "Fn::GetAtt": [
+            "IngestFunctionServiceRole55EB4427",
+            "Arn",
+          ],
+        },
+        "Timeout": 600,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "IngestFunctionServiceRole55EB4427": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "IngestFunctionServiceRoleDefaultPolicy8EB1E4A7": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttIngestQueue2280FF4EArnFE0694A6",
+              },
+            },
+            {
+              "Action": [
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:ConditionCheckItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:UpdateItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:DescribeTable",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttTableCD117FA1ArnE2C8C204",
+                      },
+                      "/index/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttDocumentsBucket9EC9DEB9ArnEA5095A7",
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttDocumentsBucket9EC9DEB9ArnEA5095A7",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "s3vectors:GetIndex",
+                "s3vectors:PutVectors",
+                "s3vectors:ListVectors",
+                "s3vectors:DeleteVectors",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttVectorIndexIndexArnC883517D",
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/event-driven-rag/openai-api-key",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "IngestFunctionServiceRoleDefaultPolicy8EB1E4A7",
+        "Roles": [
+          {
+            "Ref": "IngestFunctionServiceRole55EB4427",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "IngestFunctionSqsEventSourceTestDataStackIngestQueueF9B87988A4E459FB": {
+      "Properties": {
+        "BatchSize": 1,
+        "EventSourceArn": {
+          "Fn::ImportValue": "TestDataStack:ExportsOutputFnGetAttIngestQueue2280FF4EArnFE0694A6",
+        },
+        "FunctionName": {
+          "Ref": "IngestFunction4B2F2EB2",
+        },
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "Repository22E53BBD": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "EmptyOnDelete": true,
+      },
+      "Type": "AWS::ECR::Repository",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/cdk/test/app-stack.test.ts
+++ b/cdk/test/app-stack.test.ts
@@ -1,0 +1,190 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import {
+  AppStack,
+  COHERE_API_KEY_PARAMETER_NAME,
+  OPENAI_API_KEY_PARAMETER_NAME,
+} from '../lib/app-stack';
+import { DataStack } from '../lib/data-stack';
+
+let template: Template;
+
+beforeAll(() => {
+  const app = new cdk.App();
+  const dataStack = new DataStack(app, 'TestDataStack');
+  const appStack = new AppStack(app, 'TestAppStack', { dataStack });
+  template = Template.fromStack(appStack);
+});
+
+// 環境変数からLambda論理リソースを特定するヘルパー
+function findFunctionByServiceName(serviceName: string) {
+  const functions = template.findResources('AWS::Lambda::Function');
+  const matched = Object.entries(functions).filter(
+    ([, fn]) =>
+      fn.Properties.Environment?.Variables?.POWERTOOLS_SERVICE_NAME === serviceName,
+  );
+  expect(matched).toHaveLength(1);
+  return matched[0];
+}
+
+describe('ECR', () => {
+  test('CI/CD用の常設リポジトリが作成される', () => {
+    template.resourceCountIs('AWS::ECR::Repository', 1);
+    template.hasResource('AWS::ECR::Repository', {
+      Properties: { EmptyOnDelete: true },
+      DeletionPolicy: 'Delete',
+    });
+  });
+});
+
+describe('Lambda', () => {
+  test('3つのコンテナイメージLambdaが作成される', () => {
+    template.resourceCountIs('AWS::Lambda::Function', 3);
+    const functions = template.findResources('AWS::Lambda::Function');
+    for (const fn of Object.values(functions)) {
+      expect(fn.Properties.PackageType).toBe('Image');
+    }
+  });
+
+  test('api-fnは512MB/30秒でDataStackのリソース名を環境変数に持つ', () => {
+    const [, fn] = findFunctionByServiceName('api');
+    expect(fn.Properties.MemorySize).toBe(512);
+    expect(fn.Properties.Timeout).toBe(30);
+    const env = fn.Properties.Environment.Variables;
+    expect(env).toHaveProperty('TABLE_NAME');
+    expect(env).toHaveProperty('DOCUMENTS_BUCKET_NAME');
+    expect(env).toHaveProperty('INGEST_QUEUE_URL');
+    expect(env.POWERTOOLS_LOG_LEVEL).toBe('INFO');
+  });
+
+  test('chat-fnは1024MB/300秒でストリーミングとSSMパラメータ名を設定する', () => {
+    const [, fn] = findFunctionByServiceName('chat');
+    expect(fn.Properties.MemorySize).toBe(1024);
+    expect(fn.Properties.Timeout).toBe(300);
+    const env = fn.Properties.Environment.Variables;
+    expect(env.AWS_LWA_INVOKE_MODE).toBe('response_stream');
+    expect(env.OPENAI_API_KEY_PARAMETER_NAME).toBe(OPENAI_API_KEY_PARAMETER_NAME);
+    expect(env.COHERE_API_KEY_PARAMETER_NAME).toBe(COHERE_API_KEY_PARAMETER_NAME);
+    expect(env).toHaveProperty('VECTOR_BUCKET_ARN');
+    expect(env).toHaveProperty('VECTOR_INDEX_ARN');
+  });
+
+  test('ingest-fnは1024MB/600秒でWeb Adapter用環境変数を持たない', () => {
+    const [, fn] = findFunctionByServiceName('ingest');
+    expect(fn.Properties.MemorySize).toBe(1024);
+    expect(fn.Properties.Timeout).toBe(600);
+    const env = fn.Properties.Environment.Variables;
+    expect(env).not.toHaveProperty('AWS_LWA_INVOKE_MODE');
+    expect(env.OPENAI_API_KEY_PARAMETER_NAME).toBe(OPENAI_API_KEY_PARAMETER_NAME);
+    expect(env).not.toHaveProperty('COHERE_API_KEY_PARAMETER_NAME');
+  });
+
+  test('ingest-fnはworkerターゲットの別イメージを使う', () => {
+    const [, apiFn] = findFunctionByServiceName('api');
+    const [, chatFn] = findFunctionByServiceName('chat');
+    const [, ingestFn] = findFunctionByServiceName('ingest');
+    // web(api/chat)は同一アセット、worker(ingest)は別アセット
+    expect(apiFn.Properties.Code.ImageUri).toEqual(chatFn.Properties.Code.ImageUri);
+    expect(ingestFn.Properties.Code.ImageUri).not.toEqual(apiFn.Properties.Code.ImageUri);
+  });
+});
+
+describe('Function URL', () => {
+  test('api-fnとchat-fnの2つだけ作成される', () => {
+    template.resourceCountIs('AWS::Lambda::Url', 2);
+  });
+
+  // TODO: EdgeStack実装時にAWS_IAM + CloudFront OACへ切り替える
+  test('認証タイプは当面NONEで公開される', () => {
+    const urls = template.findResources('AWS::Lambda::Url');
+    for (const url of Object.values(urls)) {
+      expect(url.Properties.AuthType).toBe('NONE');
+    }
+    template.hasResourceProperties('AWS::Lambda::Permission', {
+      Action: 'lambda:InvokeFunctionUrl',
+      Principal: '*',
+      FunctionUrlAuthType: 'NONE',
+    });
+  });
+
+  test('chat-fnのFunction URLはRESPONSE_STREAMを有効化する', () => {
+    template.hasResourceProperties('AWS::Lambda::Url', {
+      InvokeMode: 'RESPONSE_STREAM',
+    });
+  });
+});
+
+describe('SQS', () => {
+  test('ingest-fnは取込キューから1メッセージずつ受け取る', () => {
+    template.hasResourceProperties('AWS::Lambda::EventSourceMapping', {
+      BatchSize: 1,
+      EventSourceArn: Match.anyValue(),
+    });
+  });
+});
+
+describe('IAM', () => {
+  function policyStatements() {
+    const policies = template.findResources('AWS::IAM::Policy');
+    return Object.values(policies).flatMap(
+      (policy) => policy.Properties.PolicyDocument.Statement,
+    );
+  }
+
+  test('DynamoDBテーブルへの読み書き権限が付与される', () => {
+    const statement = policyStatements().find(
+      (s) => Array.isArray(s.Action) && s.Action.includes('dynamodb:PutItem'),
+    );
+    expect(statement).toBeDefined();
+  });
+
+  test('chat-fnにS3 Vectorsの検索権限が付与される', () => {
+    const statement = policyStatements().find(
+      (s) => Array.isArray(s.Action) && s.Action.includes('s3vectors:QueryVectors'),
+    );
+    expect(statement).toBeDefined();
+    expect(statement.Action).toContain('s3vectors:GetVectors');
+    expect(statement.Action).toContain('s3vectors:GetIndex');
+  });
+
+  test('ingest-fnにS3 Vectorsの登録・削除権限が付与される', () => {
+    const statement = policyStatements().find(
+      (s) => Array.isArray(s.Action) && s.Action.includes('s3vectors:PutVectors'),
+    );
+    expect(statement).toBeDefined();
+    expect(statement.Action).toContain('s3vectors:ListVectors');
+    expect(statement.Action).toContain('s3vectors:DeleteVectors');
+  });
+
+  test('SSM SecureStringの読み取り権限が付与される', () => {
+    const statements = policyStatements().filter(
+      (s) => Array.isArray(s.Action) && s.Action.includes('ssm:GetParameter'),
+    );
+    // chat-fn(openai + cohere)とingest-fn(openai)
+    expect(statements.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.stringify(statements)).toContain(
+      `parameter${OPENAI_API_KEY_PARAMETER_NAME}`,
+    );
+    expect(JSON.stringify(statements)).toContain(
+      `parameter${COHERE_API_KEY_PARAMETER_NAME}`,
+    );
+  });
+
+  test('api-fnにSQS送信権限、ingest-fnにSQS消費権限が付与される', () => {
+    const statements = policyStatements();
+    expect(
+      statements.find((s) => Array.isArray(s.Action) && s.Action.includes('sqs:SendMessage')),
+    ).toBeDefined();
+    expect(
+      statements.find(
+        (s) => Array.isArray(s.Action) && s.Action.includes('sqs:ReceiveMessage'),
+      ),
+    ).toBeDefined();
+  });
+});
+
+// backendソースの変更でイメージアセットハッシュが変わるため、
+// スナップショットはbackend編集のたびに更新される(意図した挙動)
+test('スナップショット', () => {
+  expect(template.toJSON()).toMatchSnapshot();
+});

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,8 @@ services:
   backend:
     build:
       context: apps/backend
+      # Without this, docker compose builds the last stage (worker)
+      target: web
     image: event-driven-rag-backend
     ports:
       - "8000:8000"


### PR DESCRIPTION
- Implement `AppStack` in CDK to deploy three container Lambdas (`api-fn`, `chat-fn`, and `ingest-fn`).
- Update `apps/backend/Dockerfile` to support multi-stage targets: `web` (for API/Chat via LWA) and `worker` (for Ingest via `awslambdaric`).
- Add a stub SQS-triggered `ingest_handler.py` with partial batch failure handling.
- Add `worker` dependency group containing `awslambdaric` in `pyproject.toml`.
- Configure `compose.yaml` to explicitly target the `web` stage for local development.
- Include snapshot and integration tests for the new `AppStack`.

---

Closes #4 