### PR TITLE
Feature/documents chats api

### DIFF
--- a/apps/backend/app/dependencies.py
+++ b/apps/backend/app/dependencies.py
@@ -1,0 +1,42 @@
+"""複数のルーターで共有するFastAPI DIファクトリ。"""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from app.ingest_queue import IngestQueue
+from app.repositories.chats import ChatRepository
+from app.repositories.documents import DocumentRepository
+from app.repositories.users import UserRepository
+from app.settings import Settings, get_settings
+from app.storage import DocumentStorage
+
+
+def get_document_repository(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> DocumentRepository:
+    return DocumentRepository(settings.table_name)
+
+
+def get_chat_repository(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ChatRepository:
+    return ChatRepository(settings.table_name)
+
+
+def get_user_repository(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> UserRepository:
+    return UserRepository(settings.table_name)
+
+
+def get_document_storage(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> DocumentStorage:
+    return DocumentStorage(settings.documents_bucket_name)
+
+
+def get_ingest_queue(
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> IngestQueue:
+    return IngestQueue(settings.ingest_queue_url)

--- a/apps/backend/app/ingest_handler.py
+++ b/apps/backend/app/ingest_handler.py
@@ -1,15 +1,15 @@
-"""ingest-fn entrypoint, invoked by awslambdaric (Dockerfile worker target).
-
-Runs as a plain Lambda handler triggered by SQS — no Web Adapter, no FastAPI.
-Text extraction / chunking / embedding / S3 Vectors registration will be
-implemented in a later issue; for now the handler only logs received messages.
+"""ingest-fn のエントリポイント
+Dockerfileの worker ターゲットで awslambdaric により呼び出される。
+SQSによってトリガーされる通常のLambdaハンドラーとして動作する（Web AdapterやFastAPIは不使用）。
+テキスト抽出 / チャンク分割 / Embedding / S3 Vectors への登録は後で実装予定。
+現時点では、ハンドラーは受信したメッセージのログ出力のみを行う。
 """
 
 import logging
 
 logger = logging.getLogger(__name__)
-# The Lambda runtime already attaches a handler to the root logger, so
-# logging.basicConfig() is a no-op here; set the level directly instead.
+# Lambdaの実行環境がすでにルートロガーにハンドラーを追加しているため、
+# logging.basicConfig() は効果がない（no-op）。そのため直接ログレベルを設定する。
 logger.setLevel(logging.INFO)
 
 
@@ -18,5 +18,5 @@ def handler(event, context):
     logger.info("received %d ingest message(s)", len(records))
     for record in records:
         logger.info("messageId=%s body=%s", record.get("messageId"), record.get("body"))
-    # Partial-batch response shape; empty means every record succeeded.
+    # バッチの一部失敗用レスポンス形式。空の場合はすべてのレコードが成功したことを意味する。
     return {"batchItemFailures": []}

--- a/apps/backend/app/ingest_queue.py
+++ b/apps/backend/app/ingest_queue.py
@@ -1,0 +1,30 @@
+import json
+
+import boto3
+
+
+class IngestQueue:
+    """取込要求をingest-fnへ渡すSQSキュー。"""
+
+    def __init__(self, queue_url: str) -> None:
+        self._queue_url = queue_url
+        self._client = boto3.client("sqs")
+
+    # 呼び出し側に必ず引数名を書かせ、似た文字列引数の順序間違いを防ぐ
+    def send(
+        self, *, document_id: str, user_id: str, s3_key: str, request_id: str
+    ) -> None:
+        # request_idはRequest ID伝搬のために載せ、ingest-fnがログへ引き継ぐ
+        self._client.send_message(
+            QueueUrl=self._queue_url,
+            MessageBody=json.dumps(
+                {
+                    "documentId": document_id,
+                    "userId": user_id,
+                    "s3Key": s3_key,
+                    "requestId": request_id,
+                },
+                # 日本語などをエスケープせず、日本語のままJSON変換
+                ensure_ascii=False,
+            ),
+        )

--- a/apps/backend/app/logger.py
+++ b/apps/backend/app/logger.py
@@ -1,0 +1,4 @@
+from aws_lambda_powertools import Logger
+
+# サービス名とログレベルはPOWERTOOLS_SERVICE_NAME / POWERTOOLS_LOG_LEVELから解決される
+logger = Logger()

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -4,7 +4,7 @@ import uuid
 from fastapi import APIRouter, FastAPI, Request
 
 from app.logger import logger
-from app.routers import users
+from app.routers import chats, documents, users
 
 app = FastAPI()
 
@@ -47,4 +47,6 @@ def health():
 
 
 router.include_router(users.router)
+router.include_router(documents.router)
+router.include_router(chats.router)
 app.include_router(router)

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,8 +1,42 @@
-from fastapi import APIRouter, FastAPI
+import json
+import uuid
 
+from fastapi import APIRouter, FastAPI, Request
+
+from app.logger import logger
 from app.routers import users
 
 app = FastAPI()
+
+
+def _lambda_request_id(request: Request) -> str | None:
+    """Lambda Web Adapterが転送するLambda contextからrequest IDを取り出す。"""
+    header = request.headers.get("x-amzn-lambda-context")
+    if not header:
+        return None
+    try:
+        return json.loads(header).get("request_id")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+@app.middleware("http")
+async def request_logging_middleware(request: Request, call_next):
+    """Request IDを全ログへ付与し、X-Request-Idヘッダとアクセスログを出力する。"""
+    # ローカル実行などLambda contextがない場合はUUIDで代替する
+    request_id = _lambda_request_id(request) or str(uuid.uuid4())
+    request.state.request_id = request_id
+    logger.append_keys(request_id=request_id)
+    response = await call_next(request)
+    response.headers["X-Request-Id"] = request_id
+    logger.info(
+        "request completed",
+        method=request.method,
+        path=request.url.path,
+        status_code=response.status_code,
+    )
+    return response
+
 
 router = APIRouter(prefix="/api")
 

--- a/apps/backend/app/repositories/chats.py
+++ b/apps/backend/app/repositories/chats.py
@@ -1,0 +1,53 @@
+import boto3
+from boto3.dynamodb.conditions import Key
+
+
+class ChatRepository:
+    """DynamoDBシングルテーブルのChat / Chat Messagesエンティティを扱う。
+
+    書き込みはchat-fnが行い、api-fnは読み取りのみ。アイテム構造は次のとおり。
+
+    - Chat:    SK=CHAT#<chatId>、GSI1PK=CHAT、GSI1SK=<chatId>
+               question / finalAnswer / finalGrade / retryCount / createdAt
+    - Attempt: SK=MSG#<chatId>#<attemptNo>
+               queries / documents / answer / grade / feedback / failureAnalysis
+
+    chatIdはULIDのため、辞書順がそのまま作成時刻順になる。
+    """
+
+    def __init__(self, table_name: str) -> None:
+        self._table = boto3.resource("dynamodb").Table(table_name)
+
+    def get(self, chat_id: str) -> dict | None:
+        """所有者を問わずchatIdで取得する。チャット詳細画面の入口。"""
+        res = self._table.query(
+            IndexName="GSI1",
+            KeyConditionExpression=Key("GSI1PK").eq("CHAT") & Key("GSI1SK").eq(chat_id),
+        )
+        items = res["Items"]
+        return items[0] if items else None
+
+    def list_recent(self, limit: int) -> list[dict]:
+        res = self._table.query(
+            IndexName="GSI1",
+            KeyConditionExpression=Key("GSI1PK").eq("CHAT"),
+            ScanIndexForward=False,
+            Limit=limit,
+        )
+        return res["Items"]
+
+    def list_by_user(self, user_id: str, limit: int) -> list[dict]:
+        res = self._table.query(
+            KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with("CHAT#"),
+            ScanIndexForward=False,
+            Limit=limit,
+        )
+        return res["Items"]
+
+    def list_attempts(self, user_id: str, chat_id: str) -> list[dict]:
+        res = self._table.query(
+            KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with(f"MSG#{chat_id}#"),
+        )
+        return res["Items"]

--- a/apps/backend/app/repositories/documents.py
+++ b/apps/backend/app/repositories/documents.py
@@ -1,0 +1,102 @@
+from datetime import UTC, datetime
+
+import boto3
+from boto3.dynamodb.conditions import Attr, Key
+
+
+class DocumentStatusError(Exception):
+    """現在のステータスからは許可されない遷移。"""
+
+
+class DocumentRepository:
+    """DynamoDBシングルテーブルのDocumentsエンティティを扱う。
+
+    ステータス遷移: uploading → uploaded → processing → ingested | failed
+    SK・GSI1SKのdocumentIdはULIDのため、辞書順がそのまま作成時刻順になる。
+    """
+
+    def __init__(self, table_name: str) -> None:
+        self._table = boto3.resource("dynamodb").Table(table_name)
+
+    def create(
+        self, *, user_id: str, document_id: str, filename: str, s3_key: str
+    ) -> dict:
+        now = datetime.now(UTC).isoformat()
+        item = {
+            "PK": f"USER#{user_id}",
+            "SK": f"DOC#{document_id}",
+            "GSI1PK": "DOC",
+            "GSI1SK": document_id,
+            "documentId": document_id,
+            "userId": user_id,
+            "filename": filename,
+            "s3Key": s3_key,
+            "status": "uploading",
+            "createdAt": now,
+            "updatedAt": now,
+        }
+        self._table.put_item(Item=item)
+        return item
+
+    def get_owned(self, user_id: str, document_id: str) -> dict | None:
+        """本人のドキュメントを取得する。ステータス更新系の所有チェックに使う。"""
+        res = self._table.get_item(
+            Key={"PK": f"USER#{user_id}", "SK": f"DOC#{document_id}"}
+        )
+        return res.get("Item")
+
+    def get(self, document_id: str) -> dict | None:
+        """所有者を問わずdocumentIdで取得する。閲覧用presigned URL発行に使う。"""
+        res = self._table.query(
+            IndexName="GSI1",
+            KeyConditionExpression=Key("GSI1PK").eq("DOC")
+            & Key("GSI1SK").eq(document_id),
+        )
+        items = res["Items"]
+        return items[0] if items else None
+
+    def list_recent(self, limit: int) -> list[dict]:
+        res = self._table.query(
+            IndexName="GSI1",
+            KeyConditionExpression=Key("GSI1PK").eq("DOC"),
+            ScanIndexForward=False,
+            Limit=limit,
+        )
+        return res["Items"]
+
+    def list_by_user(self, user_id: str, limit: int) -> list[dict]:
+        res = self._table.query(
+            KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
+            & Key("SK").begins_with("DOC#"),
+            ScanIndexForward=False,
+            Limit=limit,
+        )
+        return res["Items"]
+
+    def update_status(
+        self,
+        user_id: str,
+        document_id: str,
+        new_status: str,
+        *,
+        allowed_from: tuple[str, ...],
+    ) -> None:
+        """条件付き更新でステータスを遷移させる。
+
+        現在のステータスがallowed_from外の場合はDocumentStatusErrorを送出する。
+        """
+        try:
+            self._table.update_item(
+                Key={"PK": f"USER#{user_id}", "SK": f"DOC#{document_id}"},
+                UpdateExpression="SET #status = :status, updatedAt = :now",
+                ConditionExpression=Attr("status").is_in(list(allowed_from)),
+                ExpressionAttributeNames={"#status": "status"},
+                ExpressionAttributeValues={
+                    ":status": new_status,
+                    ":now": datetime.now(UTC).isoformat(),
+                },
+            )
+        except self._table.meta.client.exceptions.ConditionalCheckFailedException:
+            raise DocumentStatusError(
+                f"transition to {new_status} requires status in {allowed_from}"
+            ) from None

--- a/apps/backend/app/repositories/users.py
+++ b/apps/backend/app/repositories/users.py
@@ -13,6 +13,10 @@ class UserRepository:
     def __init__(self, table_name: str) -> None:
         self._table = boto3.resource("dynamodb").Table(table_name)
 
+    def get_profile(self, user_id: str) -> dict | None:
+        res = self._table.get_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"})
+        return res.get("Item")
+
     def upsert_profile(self, user_id: str, display_name: str, email: str) -> None:
         now = datetime.now(UTC).isoformat()
         self._table.update_item(

--- a/apps/backend/app/routers/chats.py
+++ b/apps/backend/app/routers/chats.py
@@ -1,0 +1,58 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from app.auth import get_current_user_id
+from app.dependencies import get_chat_repository
+from app.repositories.chats import ChatRepository
+from app.schemas import ChatSummaryResponse
+
+router = APIRouter(prefix="/chats")
+
+
+class RetrievedDocumentResponse(BaseModel):
+    document_id: str | None = Field(alias="documentId", default=None)
+    filename: str | None = None
+    text: str | None = None
+    score: float | None = None
+
+
+class ChatAttemptResponse(BaseModel):
+    attempt_no: int = Field(alias="attemptNo")
+    queries: list[str] = []
+    documents: list[RetrievedDocumentResponse] = []
+    answer: str | None = None
+    grade: str | None = None
+    feedback: str | None = None
+    failure_analysis: str | None = Field(alias="failureAnalysis", default=None)
+
+
+class ChatDetailResponse(ChatSummaryResponse):
+    attempts: list[ChatAttemptResponse]
+
+
+@router.get("")
+def list_chats(
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[ChatRepository, Depends(get_chat_repository)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> list[ChatSummaryResponse]:
+    """全ユーザーのチャット一覧を新しい順で返す。"""
+    return [
+        ChatSummaryResponse.model_validate(i) for i in repository.list_recent(limit)
+    ]
+
+
+@router.get("/{chat_id}")
+def get_chat(
+    chat_id: str,
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[ChatRepository, Depends(get_chat_repository)],
+) -> ChatDetailResponse:
+    """チャット詳細を試行ごとの全ての出力を返す。"""
+    chat = repository.get(chat_id)
+    if chat is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="chat not found")
+    attempts = repository.list_attempts(chat["userId"], chat_id)
+    return ChatDetailResponse.model_validate({**chat, "attempts": attempts})

--- a/apps/backend/app/routers/documents.py
+++ b/apps/backend/app/routers/documents.py
@@ -1,0 +1,145 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
+from ulid import ULID
+
+from app.auth import get_current_user_id
+from app.dependencies import (
+    get_document_repository,
+    get_document_storage,
+    get_ingest_queue,
+)
+from app.ingest_queue import IngestQueue
+from app.logger import logger
+from app.repositories.documents import DocumentRepository, DocumentStatusError
+from app.schemas import DocumentResponse
+from app.storage import DocumentStorage
+
+router = APIRouter(prefix="/documents")
+
+
+class CreateUploadUrlRequest(BaseModel):
+    filename: str = Field(min_length=1)
+    content_type: str | None = Field(alias="contentType", default=None)
+
+
+class CreateUploadUrlResponse(BaseModel):
+    document_id: str = Field(alias="documentId")
+    upload_url: str = Field(alias="uploadUrl")
+
+
+class DownloadUrlResponse(BaseModel):
+    download_url: str = Field(alias="downloadUrl")
+    filename: str
+
+
+class IngestResponse(BaseModel):
+    document_id: str = Field(alias="documentId")
+    status: str
+
+
+@router.get("")
+def list_documents(
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> list[DocumentResponse]:
+    """全ユーザー横断のドキュメント一覧を新しい順で返す。"""
+    return [DocumentResponse.model_validate(i) for i in repository.list_recent(limit)]
+
+
+@router.post("/upload-url", status_code=status.HTTP_201_CREATED)
+def register_document_for_upload(
+    body: CreateUploadUrlRequest,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+    storage: Annotated[DocumentStorage, Depends(get_document_storage)],
+) -> CreateUploadUrlResponse:
+    """uploading状態のドキュメントを登録し、アップロード用presigned PUT URLを発行する。"""
+    document_id = str(ULID())
+    s3_key = f"documents/{user_id}/{document_id}/{body.filename}"
+    repository.create(
+        user_id=user_id,
+        document_id=document_id,
+        filename=body.filename,
+        s3_key=s3_key,
+    )
+    upload_url = storage.presign_put(s3_key, body.content_type)
+    logger.info("document upload url issued", document_id=document_id)
+    return CreateUploadUrlResponse(documentId=document_id, uploadUrl=upload_url)
+
+
+@router.post("/{document_id}/complete", status_code=status.HTTP_204_NO_CONTENT)
+def complete_upload(
+    document_id: str,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+) -> None:
+    """S3へのアップロード完了を登録し、ステータスをuploadedにする(冪等)。"""
+    if repository.get_owned(user_id, document_id) is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="document not found")
+    try:
+        repository.update_status(
+            user_id, document_id, "uploaded", allowed_from=("uploading", "uploaded")
+        )
+    except DocumentStatusError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="document is not awaiting upload"
+        ) from None
+    logger.info("document upload completed", document_id=document_id)
+
+
+@router.post("/{document_id}/ingest", status_code=status.HTTP_202_ACCEPTED)
+def start_ingest(
+    document_id: str,
+    request: Request,
+    user_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+    queue: Annotated[IngestQueue, Depends(get_ingest_queue)],
+) -> IngestResponse:
+    """SQSへ取込要求を送信し、ステータスをprocessingにする。"""
+    # ステータス更新→SQS送信の順序の理由はADR-0007のAddendumを参照
+    document = repository.get_owned(user_id, document_id)
+    if document is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="document not found")
+    try:
+        repository.update_status(
+            user_id, document_id, "processing", allowed_from=("uploaded", "failed")
+        )
+    except DocumentStatusError:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, detail="document is not ready for ingest"
+        ) from None
+    try:
+        queue.send(
+            document_id=document_id,
+            user_id=user_id,
+            s3_key=document["s3Key"],
+            request_id=request.state.request_id,
+        )
+    except Exception:
+        # 送信できていないので元のステータスへ戻し、再実行できるようにする
+        repository.update_status(
+            user_id, document_id, document["status"], allowed_from=("processing",)
+        )
+        raise
+    logger.info("document ingest queued", document_id=document_id)
+    return IngestResponse(documentId=document_id, status="processing")
+
+
+@router.get("/{document_id}/download-url")
+def issue_download_url(
+    document_id: str,
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+    storage: Annotated[DocumentStorage, Depends(get_document_storage)],
+) -> DownloadUrlResponse:
+    """閲覧用presigned GET URLを発行する。全ユーザーのドキュメントを対象とする。"""
+    document = repository.get(document_id)
+    if document is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="document not found")
+    return DownloadUrlResponse(
+        downloadUrl=storage.presign_get(document["s3Key"]),
+        filename=document["filename"],
+    )

--- a/apps/backend/app/routers/users.py
+++ b/apps/backend/app/routers/users.py
@@ -1,11 +1,18 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from app.auth import get_current_user_id
+from app.dependencies import (
+    get_chat_repository,
+    get_document_repository,
+    get_user_repository,
+)
+from app.repositories.chats import ChatRepository
+from app.repositories.documents import DocumentRepository
 from app.repositories.users import UserRepository
-from app.settings import Settings, get_settings
+from app.schemas import ChatSummaryResponse, DocumentResponse
 
 router = APIRouter(prefix="/users")
 
@@ -16,10 +23,12 @@ class UpsertProfileRequest(BaseModel):
     email: str = Field(min_length=1)
 
 
-def get_user_repository(
-    settings: Annotated[Settings, Depends(get_settings)],
-) -> UserRepository:
-    return UserRepository(settings.table_name)
+class UserResponse(BaseModel):
+    user_id: str = Field(alias="userId")
+    display_name: str = Field(alias="displayName")
+    email: str
+    created_at: str = Field(alias="createdAt")
+    updated_at: str = Field(alias="updatedAt")
 
 
 @router.post("/me", status_code=status.HTTP_204_NO_CONTENT)
@@ -30,3 +39,44 @@ def upsert_me(
 ) -> None:
     """サインイン時にSPAから呼ばれ、Cognitoの表示名とメールをキャッシュする(冪等)。"""
     repository.upsert_profile(user_id, body.display_name, body.email)
+
+
+@router.get("/{user_id}")
+def get_user(
+    user_id: str,
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[UserRepository, Depends(get_user_repository)],
+) -> UserResponse:
+    """ユーザー画面表示用のプロフィールを返す。他ユーザーも取得できる。"""
+    profile = repository.get_profile(user_id)
+    if profile is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="user not found")
+    return UserResponse.model_validate({**profile, "userId": user_id})
+
+
+@router.get("/{user_id}/documents")
+def list_user_documents(
+    user_id: str,
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[DocumentRepository, Depends(get_document_repository)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> list[DocumentResponse]:
+    """指定ユーザーのドキュメント一覧を新しい順で返す。"""
+    return [
+        DocumentResponse.model_validate(i)
+        for i in repository.list_by_user(user_id, limit)
+    ]
+
+
+@router.get("/{user_id}/chats")
+def list_user_chats(
+    user_id: str,
+    _caller_id: Annotated[str, Depends(get_current_user_id)],
+    repository: Annotated[ChatRepository, Depends(get_chat_repository)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> list[ChatSummaryResponse]:
+    """指定ユーザーのチャット一覧を新しい順で返す。"""
+    return [
+        ChatSummaryResponse.model_validate(i)
+        for i in repository.list_by_user(user_id, limit)
+    ]

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1,0 +1,26 @@
+"""複数のルーターで共有するレスポンススキーマ。
+
+一覧・詳細のいずれからも参照されるモデルのみここに置く。
+エンドポイント固有のリクエスト/レスポンスは各ルーターに定義する。
+"""
+
+from pydantic import BaseModel, Field
+
+
+class DocumentResponse(BaseModel):
+    document_id: str = Field(alias="documentId")
+    user_id: str = Field(alias="userId")
+    filename: str
+    status: str
+    created_at: str = Field(alias="createdAt")
+    updated_at: str = Field(alias="updatedAt")
+
+
+class ChatSummaryResponse(BaseModel):
+    chat_id: str = Field(alias="chatId")
+    user_id: str = Field(alias="userId")
+    question: str
+    final_answer: str | None = Field(alias="finalAnswer", default=None)
+    final_grade: str | None = Field(alias="finalGrade", default=None)
+    retry_count: int = Field(alias="retryCount", default=0)
+    created_at: str = Field(alias="createdAt")

--- a/apps/backend/app/settings.py
+++ b/apps/backend/app/settings.py
@@ -3,17 +3,23 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 
+# 生成後に値を書き換えられないようにする
 @dataclass(frozen=True)
 class Settings:
     cognito_issuer: str
     cognito_client_id: str
     table_name: str
+    documents_bucket_name: str
+    ingest_queue_url: str
 
 
+# キャッシュ化により、os.environの読み込みを1回だけにする
 @lru_cache
 def get_settings() -> Settings:
     return Settings(
         cognito_issuer=os.environ["COGNITO_ISSUER"],
         cognito_client_id=os.environ["COGNITO_CLIENT_ID"],
         table_name=os.environ["TABLE_NAME"],
+        documents_bucket_name=os.environ["DOCUMENTS_BUCKET_NAME"],
+        ingest_queue_url=os.environ["INGEST_QUEUE_URL"],
     )

--- a/apps/backend/app/storage.py
+++ b/apps/backend/app/storage.py
@@ -1,0 +1,30 @@
+import boto3
+
+# presigned URLはLambdaロールで署名されるため、実行ロールに対象操作の権限が必要
+# 長すぎるとURL漏洩時のリスクが増すため15分に制限
+UPLOAD_URL_EXPIRES_IN = 900
+DOWNLOAD_URL_EXPIRES_IN = 900
+
+
+class DocumentStorage:
+    """DocumentsバケットのPresigned URLを発行する。"""
+
+    def __init__(self, bucket_name: str) -> None:
+        self._bucket_name = bucket_name
+        self._client = boto3.client("s3")
+
+    def presign_put(self, key: str, content_type: str | None = None) -> str:
+        params: dict = {"Bucket": self._bucket_name, "Key": key}
+        # ContentTypeを署名に含めることで、発行時と異なるContent-Typeでのアップロードを拒否する
+        if content_type:
+            params["ContentType"] = content_type
+        return self._client.generate_presigned_url(
+            "put_object", Params=params, ExpiresIn=UPLOAD_URL_EXPIRES_IN
+        )
+
+    def presign_get(self, key: str) -> str:
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self._bucket_name, "Key": key},
+            ExpiresIn=DOWNLOAD_URL_EXPIRES_IN,
+        )

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -5,19 +5,21 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "aws-lambda-powertools>=3.7.0",
     "boto3>=1.43.51",
     "fastapi>=0.139.2",
     "httpx>=0.28.1",
     "pydantic>=2.13.4",
     "pyjwt[crypto]>=2.13.0",
     "python-multipart>=0.0.32",
+    "python-ulid>=3.0.0",
     "uvicorn>=0.51.0",
 ]
 
 [dependency-groups]
 dev = [
     "httpx2>=2.7.0",
-    "moto[dynamodb]>=5.2.2",
+    "moto[dynamodb,s3,sqs]>=5.2.2",
     "pytest>=9.1.1",
     "ruff>=0.15.22",
 ]

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -13,6 +13,8 @@ from app.settings import get_settings
 ISSUER = "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_test"
 CLIENT_ID = "test-client-id"
 TABLE_NAME = "test-table"
+BUCKET_NAME = "test-documents-bucket"
+QUEUE_NAME = "test-ingest-queue"
 
 
 @pytest.fixture(autouse=True)
@@ -20,6 +22,9 @@ def env(monkeypatch):
     monkeypatch.setenv("COGNITO_ISSUER", ISSUER)
     monkeypatch.setenv("COGNITO_CLIENT_ID", CLIENT_ID)
     monkeypatch.setenv("TABLE_NAME", TABLE_NAME)
+    monkeypatch.setenv("DOCUMENTS_BUCKET_NAME", BUCKET_NAME)
+    # 実URLはawsフィクスチャがキュー作成後に上書きする
+    monkeypatch.setenv("INGEST_QUEUE_URL", "https://sqs.invalid/placeholder")
     # motoが実クレデンシャルへフォールバックしないようダミーを設定
     monkeypatch.setenv("AWS_DEFAULT_REGION", "ap-northeast-1")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
@@ -72,7 +77,8 @@ def make_token(rsa_key):
 
 
 @pytest.fixture
-def dynamodb_table():
+def aws(env, monkeypatch):
+    """moto上にテーブル・バケット・キューを作成し、AWSアクセスをモック化する。"""
     with mock_aws():
         table = boto3.resource("dynamodb").create_table(
             TableName=TABLE_NAME,
@@ -83,7 +89,33 @@ def dynamodb_table():
             AttributeDefinitions=[
                 {"AttributeName": "PK", "AttributeType": "S"},
                 {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "GSI1",
+                    "KeySchema": [
+                        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
             ],
             BillingMode="PAY_PER_REQUEST",
         )
-        yield table
+        s3 = boto3.client("s3")
+        s3.create_bucket(
+            Bucket=BUCKET_NAME,
+            CreateBucketConfiguration={"LocationConstraint": "ap-northeast-1"},
+        )
+        sqs = boto3.client("sqs")
+        queue_url = sqs.create_queue(QueueName=QUEUE_NAME)["QueueUrl"]
+        monkeypatch.setenv("INGEST_QUEUE_URL", queue_url)
+        get_settings.cache_clear()
+        yield SimpleNamespace(table=table, s3=s3, sqs=sqs, queue_url=queue_url)
+
+
+@pytest.fixture
+def dynamodb_table(aws):
+    return aws.table

--- a/apps/backend/tests/factories.py
+++ b/apps/backend/tests/factories.py
@@ -1,0 +1,91 @@
+"""DynamoDBへテストデータを直接投入するヘルパー。
+
+書き込みAPIがapi-fnにないエンティティ(Chat / Chat Messages)のシードと、
+任意のステータスを持つDocumentの準備に使う。キー構造はRepositoryと同一。
+"""
+
+from datetime import UTC, datetime
+
+
+def put_document(
+    table,
+    *,
+    user_id: str,
+    document_id: str,
+    filename: str = "doc.pdf",
+    status: str = "uploaded",
+    created_at: str | None = None,
+) -> dict:
+    now = created_at or datetime.now(UTC).isoformat()
+    item = {
+        "PK": f"USER#{user_id}",
+        "SK": f"DOC#{document_id}",
+        "GSI1PK": "DOC",
+        "GSI1SK": document_id,
+        "documentId": document_id,
+        "userId": user_id,
+        "filename": filename,
+        "s3Key": f"documents/{user_id}/{document_id}/{filename}",
+        "status": status,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    table.put_item(Item=item)
+    return item
+
+
+def put_chat(
+    table,
+    *,
+    user_id: str,
+    chat_id: str,
+    question: str = "質問",
+    final_answer: str | None = "回答",
+    final_grade: str | None = "useful",
+    retry_count: int = 0,
+    created_at: str | None = None,
+) -> dict:
+    item = {
+        "PK": f"USER#{user_id}",
+        "SK": f"CHAT#{chat_id}",
+        "GSI1PK": "CHAT",
+        "GSI1SK": chat_id,
+        "chatId": chat_id,
+        "userId": user_id,
+        "question": question,
+        "finalAnswer": final_answer,
+        "finalGrade": final_grade,
+        "retryCount": retry_count,
+        "createdAt": created_at or datetime.now(UTC).isoformat(),
+    }
+    table.put_item(Item=item)
+    return item
+
+
+def put_attempt(
+    table,
+    *,
+    user_id: str,
+    chat_id: str,
+    attempt_no: int,
+    queries: list[str] | None = None,
+    documents: list[dict] | None = None,
+    answer: str | None = "回答",
+    grade: str | None = "useful",
+    feedback: str | None = "根拠が十分",
+    failure_analysis: str | None = None,
+) -> dict:
+    item = {
+        "PK": f"USER#{user_id}",
+        "SK": f"MSG#{chat_id}#{attempt_no}",
+        "chatId": chat_id,
+        "attemptNo": attempt_no,
+        "queries": queries or ["クエリ1", "クエリ2", "クエリ3"],
+        "documents": documents or [],
+        "answer": answer,
+        "grade": grade,
+        "feedback": feedback,
+        "failureAnalysis": failure_analysis,
+    }
+    table.put_item(Item=item)
+    return item

--- a/apps/backend/tests/test_chat_repository.py
+++ b/apps/backend/tests/test_chat_repository.py
@@ -1,0 +1,44 @@
+import pytest
+
+from app.repositories.chats import ChatRepository
+from tests.conftest import TABLE_NAME
+from tests.factories import put_attempt, put_chat
+
+
+@pytest.fixture
+def repository(aws):
+    return ChatRepository(TABLE_NAME)
+
+
+def test_get_finds_chat_via_gsi_regardless_of_owner(repository, aws):
+    put_chat(aws.table, user_id="user-a", chat_id="chat-1")
+
+    assert repository.get("chat-1")["userId"] == "user-a"
+    assert repository.get("unknown") is None
+
+
+def test_lists_are_newest_first_and_scoped_by_user(repository, aws):
+    put_chat(aws.table, user_id="user-a", chat_id="chat-1")
+    put_chat(aws.table, user_id="user-b", chat_id="chat-2")
+    put_chat(aws.table, user_id="user-a", chat_id="chat-3")
+
+    assert [c["chatId"] for c in repository.list_recent(limit=50)] == [
+        "chat-3",
+        "chat-2",
+        "chat-1",
+    ]
+    assert [c["chatId"] for c in repository.list_recent(limit=1)] == ["chat-3"]
+    assert [c["chatId"] for c in repository.list_by_user("user-a", limit=50)] == [
+        "chat-3",
+        "chat-1",
+    ]
+
+
+def test_list_attempts_returns_only_target_chat_in_order(repository, aws):
+    put_chat(aws.table, user_id="user-a", chat_id="chat-1")
+    put_attempt(aws.table, user_id="user-a", chat_id="chat-1", attempt_no=0)
+    put_attempt(aws.table, user_id="user-a", chat_id="chat-1", attempt_no=1)
+    put_attempt(aws.table, user_id="user-a", chat_id="chat-2", attempt_no=0)
+
+    attempts = repository.list_attempts("user-a", "chat-1")
+    assert [a["attemptNo"] for a in attempts] == [0, 1]

--- a/apps/backend/tests/test_chats_api.py
+++ b/apps/backend/tests/test_chats_api.py
@@ -1,0 +1,132 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from ulid import ULID
+
+from app.main import app
+from tests.factories import put_attempt, put_chat
+
+client = TestClient(app)
+
+
+def headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def ulid_at(second: int) -> str:
+    """指定秒のタイムスタンプを持つULIDを返す。ランダム部を含むため呼ぶたびに異なる。"""
+    return str(ULID.from_datetime(datetime(2026, 7, 23, 10, 0, second, tzinfo=UTC)))
+
+
+def test_chat_list_is_cross_user_newest_first(make_token, aws):
+    chat1, chat2, chat3 = ulid_at(1), ulid_at(2), ulid_at(3)
+    put_chat(aws.table, user_id="user-a", chat_id=chat1, question="質問1")
+    put_chat(aws.table, user_id="user-b", chat_id=chat2, question="質問2")
+    put_chat(aws.table, user_id="user-a", chat_id=chat3, question="質問3")
+
+    res = client.get("/api/chats", headers=headers(make_token()))
+    assert res.status_code == 200
+    chats = res.json()
+    assert [c["chatId"] for c in chats] == [chat3, chat2, chat1]
+    assert chats[0]["question"] == "質問3"
+    assert chats[0]["finalAnswer"] == "回答"
+    assert chats[0]["finalGrade"] == "useful"
+    assert chats[0]["retryCount"] == 0
+
+
+def test_user_chat_list_returns_only_own_chats(make_token, aws):
+    chat1, chat2 = ulid_at(1), ulid_at(2)
+    put_chat(aws.table, user_id="user-a", chat_id=chat1)
+    put_chat(aws.table, user_id="user-b", chat_id=chat2)
+
+    res = client.get("/api/users/user-a/chats", headers=headers(make_token()))
+    assert res.status_code == 200
+    assert [c["chatId"] for c in res.json()] == [chat1]
+
+
+def test_chat_detail_returns_all_outputs_per_attempt(make_token, aws):
+    chat_id = ulid_at(1)
+    put_chat(
+        aws.table,
+        user_id="user-a",
+        chat_id=chat_id,
+        question="RAGとは",
+        final_answer=None,
+        final_grade="useless",
+        retry_count=1,
+    )
+    put_attempt(
+        aws.table,
+        user_id="user-a",
+        chat_id=chat_id,
+        attempt_no=0,
+        queries=["RAGの定義", "RAGの仕組み"],
+        documents=[
+            {
+                "documentId": "doc-1",
+                "filename": "rag.pdf",
+                "text": "RAGは検索拡張生成である",
+                # DynamoDBはfloatを扱えないためDecimalで保存される
+                "score": Decimal("0.9"),
+            }
+        ],
+        answer="初回回答",
+        grade="useless",
+        feedback="根拠不足",
+    )
+    put_attempt(
+        aws.table,
+        user_id="user-a",
+        chat_id=chat_id,
+        attempt_no=1,
+        answer=None,
+        grade="useless",
+        feedback="根拠不足",
+        failure_analysis="検索対象に該当資料がない",
+    )
+
+    res = client.get(f"/api/chats/{chat_id}", headers=headers(make_token()))
+    assert res.status_code == 200
+    body = res.json()
+    assert body["chatId"] == chat_id
+    assert body["userId"] == "user-a"
+    assert body["question"] == "RAGとは"
+    assert body["retryCount"] == 1
+
+    attempts = body["attempts"]
+    assert [a["attemptNo"] for a in attempts] == [0, 1]
+    assert attempts[0]["queries"] == ["RAGの定義", "RAGの仕組み"]
+    assert attempts[0]["documents"] == [
+        {
+            "documentId": "doc-1",
+            "filename": "rag.pdf",
+            "text": "RAGは検索拡張生成である",
+            "score": 0.9,
+        }
+    ]
+    assert attempts[0]["answer"] == "初回回答"
+    assert attempts[0]["grade"] == "useless"
+    assert attempts[0]["failureAnalysis"] is None
+    assert attempts[1]["failureAnalysis"] == "検索対象に該当資料がない"
+
+
+def test_attempts_from_other_chats_are_excluded(make_token, aws):
+    chat_id = ulid_at(1)
+    other_id = ulid_at(2)
+    put_chat(aws.table, user_id="user-a", chat_id=chat_id)
+    put_chat(aws.table, user_id="user-a", chat_id=other_id)
+    put_attempt(aws.table, user_id="user-a", chat_id=chat_id, attempt_no=0)
+    put_attempt(aws.table, user_id="user-a", chat_id=other_id, attempt_no=0)
+
+    res = client.get(f"/api/chats/{chat_id}", headers=headers(make_token()))
+    assert len(res.json()["attempts"]) == 1
+
+
+def test_unknown_chat_returns_404(make_token, aws):
+    res = client.get("/api/chats/unknown-chat", headers=headers(make_token()))
+    assert res.status_code == 404
+
+
+def test_missing_token_returns_401(aws):
+    assert client.get("/api/chats").status_code == 401

--- a/apps/backend/tests/test_document_repository.py
+++ b/apps/backend/tests/test_document_repository.py
@@ -1,0 +1,69 @@
+import pytest
+
+from app.repositories.documents import DocumentRepository, DocumentStatusError
+from tests.conftest import TABLE_NAME
+from tests.factories import put_document
+
+
+@pytest.fixture
+def repository(aws):
+    return DocumentRepository(TABLE_NAME)
+
+
+def test_create_puts_item_with_uploading_status(repository, aws):
+    repository.create(
+        user_id="user-a",
+        document_id="doc-1",
+        filename="spec.pdf",
+        s3_key="documents/user-a/doc-1/spec.pdf",
+    )
+
+    item = repository.get_owned("user-a", "doc-1")
+    assert item["status"] == "uploading"
+    assert item["GSI1PK"] == "DOC"
+    assert item["GSI1SK"] == "doc-1"
+    assert item["createdAt"] == item["updatedAt"]
+
+
+def test_get_finds_document_via_gsi_regardless_of_owner(repository, aws):
+    put_document(aws.table, user_id="user-a", document_id="doc-1")
+
+    assert repository.get("doc-1")["userId"] == "user-a"
+    assert repository.get("unknown") is None
+    assert repository.get_owned("user-other", "doc-1") is None
+
+
+def test_update_status_allows_only_permitted_transitions(repository, aws):
+    put_document(aws.table, user_id="user-a", document_id="doc-1", status="uploading")
+
+    repository.update_status(
+        "user-a", "doc-1", "uploaded", allowed_from=("uploading", "uploaded")
+    )
+    assert repository.get_owned("user-a", "doc-1")["status"] == "uploaded"
+
+    with pytest.raises(DocumentStatusError):
+        repository.update_status(
+            "user-a", "doc-1", "uploaded", allowed_from=("uploading",)
+        )
+    # 失敗した遷移でステータスは変わらない
+    assert repository.get_owned("user-a", "doc-1")["status"] == "uploaded"
+
+
+def test_lists_are_newest_first_and_scoped_by_user(repository, aws):
+    put_document(aws.table, user_id="user-a", document_id="doc-1")
+    put_document(aws.table, user_id="user-b", document_id="doc-2")
+    put_document(aws.table, user_id="user-a", document_id="doc-3")
+
+    assert [d["documentId"] for d in repository.list_recent(limit=50)] == [
+        "doc-3",
+        "doc-2",
+        "doc-1",
+    ]
+    assert [d["documentId"] for d in repository.list_recent(limit=2)] == [
+        "doc-3",
+        "doc-2",
+    ]
+    assert [d["documentId"] for d in repository.list_by_user("user-a", limit=50)] == [
+        "doc-3",
+        "doc-1",
+    ]

--- a/apps/backend/tests/test_documents_api.py
+++ b/apps/backend/tests/test_documents_api.py
@@ -1,0 +1,217 @@
+import json
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from ulid import ULID
+
+from app.main import app
+from tests.conftest import BUCKET_NAME
+from tests.factories import put_document
+
+client = TestClient(app)
+
+
+def headers(token: str, **extra: str) -> dict:
+    return {"Authorization": f"Bearer {token}", **extra}
+
+
+def create_upload_url(token: str, filename: str = "spec.pdf"):
+    return client.post(
+        "/api/documents/upload-url", json={"filename": filename}, headers=headers(token)
+    )
+
+
+def get_document_item(table, user_id: str, document_id: str) -> dict | None:
+    res = table.get_item(Key={"PK": f"USER#{user_id}", "SK": f"DOC#{document_id}"})
+    return res.get("Item")
+
+
+def ulid_at(second: int) -> str:
+    """指定秒のタイムスタンプを持つULIDを返す。ランダム部を含むため呼ぶ度に異なる。"""
+    return str(ULID.from_datetime(datetime(2026, 7, 23, 10, 0, second, tzinfo=UTC)))
+
+
+def test_upload_url_issuance_registers_uploading_document(make_token, aws):
+    res = create_upload_url(make_token(sub="user-abc"), "仕様書.pdf")
+    assert res.status_code == 201
+
+    body = res.json()
+    document_id = body["documentId"]
+    assert BUCKET_NAME in body["uploadUrl"]
+    assert document_id in body["uploadUrl"]
+    # ローカル実行時のRequest IDはUUIDへフォールバックして必ず付与される
+    assert res.headers["X-Request-Id"]
+
+    item = get_document_item(aws.table, "user-abc", document_id)
+    assert item is not None
+    assert item["status"] == "uploading"
+    assert item["filename"] == "仕様書.pdf"
+    assert item["s3Key"] == f"documents/user-abc/{document_id}/仕様書.pdf"
+    assert item["GSI1PK"] == "DOC"
+    assert item["GSI1SK"] == document_id
+
+
+def test_complete_upload_sets_status_uploaded(make_token, aws):
+    token = make_token(sub="user-abc")
+    document_id = create_upload_url(token).json()["documentId"]
+
+    res = client.post(f"/api/documents/{document_id}/complete", headers=headers(token))
+    assert res.status_code == 204
+    assert get_document_item(aws.table, "user-abc", document_id)["status"] == "uploaded"
+
+
+def test_complete_upload_is_idempotent(make_token, aws):
+    token = make_token(sub="user-abc")
+    document_id = create_upload_url(token).json()["documentId"]
+    client.post(f"/api/documents/{document_id}/complete", headers=headers(token))
+
+    res = client.post(f"/api/documents/{document_id}/complete", headers=headers(token))
+    assert res.status_code == 204
+
+
+def test_complete_unknown_document_returns_404(make_token, aws):
+    res = client.post(
+        "/api/documents/unknown-doc/complete", headers=headers(make_token())
+    )
+    assert res.status_code == 404
+
+
+def test_complete_other_users_document_returns_404(make_token, aws):
+    document_id = create_upload_url(make_token(sub="user-abc")).json()["documentId"]
+
+    res = client.post(
+        f"/api/documents/{document_id}/complete",
+        headers=headers(make_token(sub="user-other")),
+    )
+    assert res.status_code == 404
+
+
+def test_complete_from_processed_status_returns_409(make_token, aws):
+    put_document(aws.table, user_id="user-abc", document_id="doc-1", status="ingested")
+
+    res = client.post(
+        "/api/documents/doc-1/complete", headers=headers(make_token(sub="user-abc"))
+    )
+    assert res.status_code == 409
+
+
+def test_start_ingest_sends_sqs_message_and_sets_processing(make_token, aws):
+    token = make_token(sub="user-abc")
+    document_id = create_upload_url(token).json()["documentId"]
+    client.post(f"/api/documents/{document_id}/complete", headers=headers(token))
+
+    lambda_context = json.dumps({"request_id": "req-123"})
+    res = client.post(
+        f"/api/documents/{document_id}/ingest",
+        headers=headers(token, **{"x-amzn-lambda-context": lambda_context}),
+    )
+    assert res.status_code == 202
+    assert res.json() == {"documentId": document_id, "status": "processing"}
+    assert res.headers["X-Request-Id"] == "req-123"
+    assert (
+        get_document_item(aws.table, "user-abc", document_id)["status"] == "processing"
+    )
+
+    messages = aws.sqs.receive_message(QueueUrl=aws.queue_url, MaxNumberOfMessages=10)
+    bodies = [json.loads(m["Body"]) for m in messages["Messages"]]
+    assert bodies == [
+        {
+            "documentId": document_id,
+            "userId": "user-abc",
+            "s3Key": f"documents/user-abc/{document_id}/spec.pdf",
+            "requestId": "req-123",
+        }
+    ]
+
+
+def test_ingest_before_upload_complete_returns_409(make_token, aws):
+    token = make_token(sub="user-abc")
+    document_id = create_upload_url(token).json()["documentId"]
+
+    res = client.post(f"/api/documents/{document_id}/ingest", headers=headers(token))
+    assert res.status_code == 409
+
+
+def test_double_ingest_returns_409(make_token, aws):
+    put_document(
+        aws.table, user_id="user-abc", document_id="doc-1", status="processing"
+    )
+
+    res = client.post(
+        "/api/documents/doc-1/ingest", headers=headers(make_token(sub="user-abc"))
+    )
+    assert res.status_code == 409
+
+
+def test_failed_document_can_be_reingested(make_token, aws):
+    put_document(aws.table, user_id="user-abc", document_id="doc-1", status="failed")
+
+    res = client.post(
+        "/api/documents/doc-1/ingest", headers=headers(make_token(sub="user-abc"))
+    )
+    assert res.status_code == 202
+    assert get_document_item(aws.table, "user-abc", "doc-1")["status"] == "processing"
+
+
+def test_download_url_available_for_other_users_document(make_token, aws):
+    put_document(
+        aws.table, user_id="user-abc", document_id="doc-1", filename="共有資料.pdf"
+    )
+
+    res = client.get(
+        "/api/documents/doc-1/download-url",
+        headers=headers(make_token(sub="user-other")),
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["filename"] == "共有資料.pdf"
+    assert BUCKET_NAME in body["downloadUrl"]
+    assert "doc-1" in body["downloadUrl"]
+
+
+def test_download_url_unknown_document_returns_404(make_token, aws):
+    res = client.get(
+        "/api/documents/unknown-doc/download-url", headers=headers(make_token())
+    )
+    assert res.status_code == 404
+
+
+def test_document_list_is_cross_user_newest_first(make_token, aws):
+    doc1, doc2, doc3 = ulid_at(1), ulid_at(2), ulid_at(3)
+    put_document(aws.table, user_id="user-a", document_id=doc1)
+    put_document(aws.table, user_id="user-b", document_id=doc2)
+    put_document(aws.table, user_id="user-a", document_id=doc3)
+
+    res = client.get("/api/documents", headers=headers(make_token()))
+    assert res.status_code == 200
+    docs = res.json()
+    assert [d["documentId"] for d in docs] == [doc3, doc2, doc1]
+    assert docs[0]["userId"] == "user-a"
+    assert docs[0]["status"] == "uploaded"
+
+
+def test_document_list_respects_limit(make_token, aws):
+    doc1, doc2, doc3 = ulid_at(1), ulid_at(2), ulid_at(3)
+    for document_id in (doc1, doc2, doc3):
+        put_document(aws.table, user_id="user-a", document_id=document_id)
+
+    res = client.get("/api/documents?limit=2", headers=headers(make_token()))
+    assert [d["documentId"] for d in res.json()] == [doc3, doc2]
+
+
+def test_user_document_list_returns_only_own_documents(make_token, aws):
+    doc1, doc2 = ulid_at(1), ulid_at(2)
+    put_document(aws.table, user_id="user-a", document_id=doc1)
+    put_document(aws.table, user_id="user-b", document_id=doc2)
+
+    res = client.get("/api/users/user-a/documents", headers=headers(make_token()))
+    assert res.status_code == 200
+    assert [d["documentId"] for d in res.json()] == [doc1]
+
+
+def test_missing_token_returns_401(aws):
+    assert client.get("/api/documents").status_code == 401
+    assert (
+        client.post("/api/documents/upload-url", json={"filename": "a"}).status_code
+        == 401
+    )

--- a/apps/backend/tests/test_users_api.py
+++ b/apps/backend/tests/test_users_api.py
@@ -51,3 +51,28 @@ def test_missing_token_returns_401(dynamodb_table):
 def test_empty_display_name_returns_422(make_token, dynamodb_table):
     res = post_me(make_token(), {"displayName": "", "email": "taro@example.com"})
     assert res.status_code == 422
+
+
+def test_can_get_other_users_profile(make_token, dynamodb_table):
+    post_me(
+        make_token(sub="user-abc"),
+        {"displayName": "山田 太郎", "email": "taro@example.com"},
+    )
+
+    res = client.get(
+        "/api/users/user-abc",
+        headers={"Authorization": f"Bearer {make_token(sub='user-other')}"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["userId"] == "user-abc"
+    assert body["displayName"] == "山田 太郎"
+    assert body["email"] == "taro@example.com"
+
+
+def test_unknown_user_returns_404(make_token, dynamodb_table):
+    res = client.get(
+        "/api/users/unknown-user",
+        headers={"Authorization": f"Bearer {make_token()}"},
+    )
+    assert res.status_code == 404

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -34,6 +34,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-lambda-powertools"
+version = "3.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/77/8c74a558facb8bebdc6f3f0096ff5735b779d57c7bbdb7948f3e6d873504/aws_lambda_powertools-3.31.1.tar.gz", hash = "sha256:b46e575c7e290c55fe81ae4a38d8b5c91238242a4644438f8b858ce535a4125c", size = 800496, upload-time = "2026-07-13T09:22:11.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/e1/67a119333cb3656b9b482a77bb4b25e0488ca969218b71479b4ecfc1a5e1/aws_lambda_powertools-3.31.1-py3-none-any.whl", hash = "sha256:cd03f824bc11b59df727744fa9a419a01772d85fd0b15a67eee07f5472b37c77", size = 957593, upload-time = "2026-07-13T09:22:09.354Z" },
+]
+
+[[package]]
 name = "awslambdaric"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -62,19 +75,21 @@ name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "aws-lambda-powertools" },
     { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
+    { name = "python-ulid" },
     { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "httpx2" },
-    { name = "moto", extra = ["dynamodb"] },
+    { name = "moto", extra = ["dynamodb", "s3"] },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -84,19 +99,21 @@ worker = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aws-lambda-powertools", specifier = ">=3.7.0" },
     { name = "boto3", specifier = ">=1.43.51" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
+    { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "uvicorn", specifier = ">=0.51.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx2", specifier = ">=2.7.0" },
-    { name = "moto", extras = ["dynamodb"], specifier = ">=5.2.2" },
+    { name = "moto", extras = ["dynamodb", "s3", "sqs"], specifier = ">=5.2.2" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.22" },
 ]
@@ -565,6 +582,10 @@ dynamodb = [
     { name = "docker" },
     { name = "py-partiql-parser" },
 ]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
 
 [[package]]
 name = "packaging"
@@ -750,6 +771,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-ulid"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/41/65079023c81491a21799c0120bce5925366b6913596bf797806f19973290/python_ulid-4.0.1.tar.gz", hash = "sha256:bbeec02556190bb9dc3401faa7268696acbfbe7b6db9908c155dc3548629f20c", size = 101683, upload-time = "2026-07-20T15:21:41.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/15/8b39b36f55b6618ec4ca9b55134dcfd9c04cecbc72709f5d8e6bdebed9cd/python_ulid-4.0.1-py3-none-any.whl", hash = "sha256:6f1d69ceb97e99fe542df8476ebcd7a668284bf53ee14b3106bcc6a341a95ed9", size = 14609, upload-time = "2026-07-20T15:21:40.214Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
feat(backend): add request-id logging middleware with Lambda Powertools

feat(backend): implement documents and chats read APIs with ingest kickoff
Add DynamoDB repositories, FastAPI routers, and user-scoped endpoints for documents and chats domains, including SQS ingest queueing.

Closes #7 