### PR TITLE
Add ingest pipeline and dependencies for PDF text extraction

### DIFF
--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -1,6 +1,6 @@
 .venv/
-__pycache__/
-*.pyc
+**/__pycache__/
+**/*.pyc
 .pytest_cache/
 .ruff_cache/
 tests/

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -7,6 +7,7 @@
 #           app.mainはlanggraphが存在する時のみSSEルーターを読み込む為、webイメージは重いライブラリを含めずに同じコードを実行可能
 # - worker: ingest-fn 用、Adapterを介さないawslambdaric経由の標準Lambdaハンドラー
 #           LWA は起動しないWebサーバーを待って初期化ブロックするため除外
+#           PDF抽出用のingestグループを追加で入れる(LangChainは含めない)
 #
 # ローカル環境では、web, chatターゲットは普通の HTTP サーバーとして動作する
 # LWAは Lambda実行環境外では動作しない為、影響しない
@@ -38,10 +39,10 @@ FROM builder AS chat-builder
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-default-groups --group chat --no-install-project
 
-# ---- worker 用ビルダー: 共通venvにawslambdaricを追加 ----
+# ---- worker 用ビルダー: 共通venvにawslambdaricとドキュメント処理依存を追加 ----
 FROM builder AS worker-builder
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-default-groups --group worker --no-install-project
+    uv sync --frozen --no-default-groups --group worker --group ingest --no-install-project
 
 # ---- web-base: LWAを使用する2ターゲットの共通ベース ----
 FROM public.ecr.aws/docker/library/python:3.12-slim AS web-base

--- a/apps/backend/app/ingest/__init__.py
+++ b/apps/backend/app/ingest/__init__.py
@@ -1,0 +1,6 @@
+"""ingest-fnのドキュメント取込処理。
+
+テキスト抽出 → チャンク分割 → Embedding生成 → S3 Vectors登録を担当する。
+worker イメージにはLangChain系ライブラリを入れない方針(ADR-0003)のため、
+chat-fn側のRAG実装(app/rag)とはコードを共有せず、軽量な実装を持つ。
+"""

--- a/apps/backend/app/ingest/chunking.py
+++ b/apps/backend/app/ingest/chunking.py
@@ -1,0 +1,84 @@
+"""抽出テキストを検索単位のチャンクへ分割する
+langchain-text-splittersはlangchain-coreを引き込みworkerイメージを重くする為、自前実装する(ADR-0003)。
+"""
+
+# 1チャンクの最大文字数と文脈を維持するために隣接チャンク間で重複させる文字数
+CHUNK_SIZE = 500
+CHUNK_OVERLAP = 50
+# 分割に使用するセパレータの優先順位
+SEPARATORS = ("\n\n", "\n", " ", "")
+
+
+def split_text(
+    text: str,
+    *,
+    chunk_size: int = CHUNK_SIZE,
+    chunk_overlap: int = CHUNK_OVERLAP,
+) -> list[str]:
+    if chunk_overlap >= chunk_size:
+        raise ValueError("chunk_overlap must be smaller than chunk_size")
+    return _split(text, SEPARATORS, chunk_size, chunk_overlap)
+
+
+def _split(
+    text: str, separators: tuple[str, ...], chunk_size: int, chunk_overlap: int
+) -> list[str]:
+    separator, remaining = _select_separator(text, separators)
+    # separator == ""のときは1文字ごとのリストlist[text]を返す
+    pieces = text.split(separator) if separator else list(text)
+
+    chunks: list[str] = []
+    # chunk_sizeに収まる断片はまとめてから結合し、細切れのチャンクを作らない
+    mergeable: list[str] = []
+    for piece in pieces:
+        if len(piece) <= chunk_size:
+            mergeable.append(piece)
+            continue
+        # 長すぎる断片は、より細かいセパレータで分割し直す
+        chunks.extend(_merge(mergeable, separator, chunk_size, chunk_overlap))
+        mergeable = []
+        chunks.extend(_split(piece, remaining, chunk_size, chunk_overlap))
+    chunks.extend(_merge(mergeable, separator, chunk_size, chunk_overlap))
+    return chunks
+
+
+def _select_separator(
+    text: str, separators: tuple[str, ...]
+) -> tuple[str, tuple[str, ...]]:
+    """テキストに含まれる最も粗いセパレータと、それより細かいセパレータ群を返す"""
+    for index, separator in enumerate(separators):
+        # separator == ""はどのseparatorでもマッチしなかった場合のフォールバック
+        if separator == "" or separator in text:
+            return separator, separators[index + 1 :]
+    return "", ()
+
+
+def _merge(
+    pieces: list[str], separator: str, chunk_size: int, chunk_overlap: int
+) -> list[str]:
+    """断片をchunk_sizeまで詰め込み、末尾chunk_overlap分を次のチャンクへ引き継ぐ"""
+    chunks: list[str] = []
+    current: list[str] = []
+    # currentをseparatorで連結したときの長さ
+    total = 0
+
+    for piece in pieces:
+        length = _joined_length(current, piece, separator)
+        if total + length > chunk_size and current:
+            chunks.append(separator.join(current).strip())
+            # オーバーラップ分だけ残るまで先頭から捨てる
+            # 次の断片が入る余地も確保する(1断片がchunk_sizeを占める場合は空になる)
+            while current and (total > chunk_overlap or total + length > chunk_size):
+                dropped = current.pop(0)
+                total -= len(dropped) + (len(separator) if current else 0)
+        current.append(piece)
+        total += length
+
+    if current:
+        chunks.append(separator.join(current).strip())
+    # 空白のみの断片はstripの結果として空文字になるため取り除く
+    return [chunk for chunk in chunks if chunk]
+
+
+def _joined_length(current: list[str], piece: str, separator: str) -> int:
+    return len(piece) + (len(separator) if current else 0)

--- a/apps/backend/app/ingest/embeddings.py
+++ b/apps/backend/app/ingest/embeddings.py
@@ -1,0 +1,63 @@
+"""Cohere Embed APIでチャンクのベクトルを生成する
+
+chat-fnの検索側(app/rag/runtime.py)と同じモデル・同じ次元数を使う。
+検索側はlangchain-cohereのCohereEmbeddingsを利用するが、workerイメージには
+LangChainを入れない方針(ADR-0003)のため、既定依存のhttpxでREST APIを直接呼ぶ。
+"""
+
+import httpx
+
+COHERE_EMBED_URL = "https://api.cohere.com/v2/embed"
+# S3 Vectorsインデックスの次元数(data-stack.tsのdimensionと一致させる)
+EMBEDDING_DIMENSION = 1536
+# Cohere Embed APIの1リクエストあたりのテキスト数上限
+MAX_TEXTS_PER_REQUEST = 96
+# Embedding生成は数秒かかるため、httpxの既定(5秒)では短い
+REQUEST_TIMEOUT_SECONDS = 60.0
+
+
+class CohereEmbedder:
+    """取込対象チャンクをsearch_documentとしてベクトル化する。"""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        dimension: int = EMBEDDING_DIMENSION,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._model = model
+        self._dimension = dimension
+        self._client = client or httpx.Client(timeout=REQUEST_TIMEOUT_SECONDS)
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        vectors: list[list[float]] = []
+        for start in range(0, len(texts), MAX_TEXTS_PER_REQUEST):
+            batch = texts[start : start + MAX_TEXTS_PER_REQUEST]
+            vectors.extend(self._embed_batch(batch))
+        return vectors
+
+    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+        response = self._client.post(
+            COHERE_EMBED_URL,
+            headers=self._headers,
+            json={
+                "model": self._model,
+                "texts": texts,
+                # 検索クエリ側はsearch_queryで埋め込まれる。取込側は文書として埋め込む
+                "input_type": "search_document",
+                "embedding_types": ["float"],
+                # embed-v4.0は出力次元を選べるため、インデックスの次元数を明示する
+                "output_dimension": self._dimension,
+            },
+        )
+        # 失敗はSQSの再試行に任せる(3回失敗でDLQへ退避)
+        response.raise_for_status()
+        embeddings = response.json()["embeddings"]["float"]
+        if len(embeddings) != len(texts):
+            raise ValueError(
+                f"cohere returned {len(embeddings)} embeddings for {len(texts)} texts"
+            )
+        return embeddings

--- a/apps/backend/app/ingest/extract.py
+++ b/apps/backend/app/ingest/extract.py
@@ -1,0 +1,45 @@
+"""アップロードされたファイルからプレーンテキストを抽出する。
+対応形式はPDF / Markdown / txt
+"""
+
+from io import BytesIO
+from pathlib import PurePosixPath
+
+from pypdf import PdfReader
+
+PDF_EXTENSIONS = {".pdf"}
+TEXT_EXTENSIONS = {".md", ".markdown", ".txt"}
+SUPPORTED_EXTENSIONS = PDF_EXTENSIONS | TEXT_EXTENSIONS
+
+
+class UnsupportedFileTypeError(Exception):
+    """対応していない拡張子のファイル。再試行しても成功しない"""
+
+
+class EmptyDocumentError(Exception):
+    """テキストを抽出できなかったファイル(画像だけのPDFなど)"""
+
+
+def extract_text(*, filename: str, body: bytes) -> str:
+    """ファイル名の拡張子から形式を判定してテキストを抽出する
+
+    Content-Typeはブラウザ依存で信頼できない為、拡張子だけで判定する
+    """
+    suffix = PurePosixPath(filename).suffix.lower()
+    if suffix in PDF_EXTENSIONS:
+        text = _extract_pdf(body)
+    elif suffix in TEXT_EXTENSIONS:
+        # 文字化けした1文字で取込全体を落とさないよう、不正なバイトは置換する
+        text = body.decode("utf-8", errors="replace")
+    else:
+        raise UnsupportedFileTypeError(f"unsupported file type: {suffix or filename}")
+
+    if not text.strip():
+        raise EmptyDocumentError(f"no text extracted from {filename}")
+    return text
+
+
+def _extract_pdf(body: bytes) -> str:
+    reader = PdfReader(BytesIO(body))
+    # ページ区切りは段落区切りとして扱い、チャンク分割の第一セパレータに合わせる
+    return "\n\n".join(page.extract_text() or "" for page in reader.pages)

--- a/apps/backend/app/ingest/pipeline.py
+++ b/apps/backend/app/ingest/pipeline.py
@@ -1,0 +1,105 @@
+"""取込処理のパイプライン。
+S3のファイルを読み、テキスト抽出 → チャンク分割 → Embedding生成 → S3 Vectors登録を行いドキュメントのステータスをingestedへ更新する。
+SSMからのAPIキー取得やクライアント生成のオーバーヘッドを避けるため、get_ingest_pipeline()はプロセス内でキャッシュする。
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import boto3
+
+from app.ingest.chunking import split_text
+from app.ingest.embeddings import CohereEmbedder
+from app.ingest.extract import extract_text
+from app.ingest.vectors import VectorIndex, vector_key
+from app.logger import logger
+from app.repositories.documents import DocumentRepository
+from app.settings import get_settings
+from app.ssm import get_parameter
+
+# 取込完了時に許可する遷移元
+INGEST_ALLOWED_FROM = ("processing", "failed", "ingested")
+
+
+class DocumentNotFoundError(Exception):
+    """SQSメッセージが指すドキュメントがDynamoDBに存在しない。"""
+
+
+@dataclass(frozen=True)
+class IngestPipeline:
+    bucket_name: str
+    repository: DocumentRepository
+    embedder: Any
+    vector_index: VectorIndex
+    s3_client: Any
+
+    def run(self, *, document_id: str, user_id: str, s3_key: str) -> int:
+        """1ドキュメントを取り込み、登録したチャンク数を返す"""
+        document = self.repository.get_owned(user_id, document_id)
+        if document is None:
+            raise DocumentNotFoundError(f"document not found: {document_id}")
+        filename = document["filename"]
+
+        body = self.s3_client.get_object(Bucket=self.bucket_name, Key=s3_key)[
+            "Body"
+        ].read()
+        text = extract_text(filename=filename, body=body)
+        chunks = split_text(text)
+        logger.info("document text extracted", chunk_count=len(chunks))
+
+        vectors = self.embedder.embed_documents(chunks)
+        self.vector_index.put_chunks(
+            document_id=document_id,
+            filename=filename,
+            chunks=chunks,
+            vectors=vectors,
+        )
+        self._delete_stale_vectors(
+            document_id=document_id,
+            # 初回取込ではchunkCountを持たないため0で代替する
+            # DynamoDBの数値はDecimalで返り、そのままではrange()に渡せない
+            previous_count=int(document.get("chunkCount", 0)),
+            current_count=len(chunks),
+        )
+
+        self.repository.update_status(
+            user_id,
+            document_id,
+            "ingested",
+            allowed_from=INGEST_ALLOWED_FROM,
+            chunk_count=len(chunks),
+        )
+        return len(chunks)
+
+    def _delete_stale_vectors(
+        self, *, document_id: str, previous_count: int, current_count: int
+    ) -> None:
+        """再取込でチャンク数が減ったときに、余った古いベクトルを削除する
+
+        既存keyは上書きされるため、超過分だけを消せば良い
+        ListVectorsにprefix絞り込みがない為、前回のチャンク数から削除対象を決める
+        """
+        if previous_count <= current_count:
+            return
+        keys = [
+            vector_key(document_id, index)
+            for index in range(current_count, previous_count)
+        ]
+        self.vector_index.delete_keys(keys)
+        logger.info("stale vectors deleted", deleted_count=len(keys))
+
+
+@lru_cache
+def get_ingest_pipeline() -> IngestPipeline:
+    settings = get_settings()
+    return IngestPipeline(
+        bucket_name=settings.documents_bucket_name,
+        repository=DocumentRepository(settings.table_name),
+        embedder=CohereEmbedder(
+            api_key=get_parameter(settings.cohere_api_key_parameter_name),
+            model=settings.cohere_embedding_model,
+        ),
+        vector_index=VectorIndex(settings.vector_index_arn),
+        s3_client=boto3.client("s3"),
+    )

--- a/apps/backend/app/ingest/vectors.py
+++ b/apps/backend/app/ingest/vectors.py
@@ -1,0 +1,61 @@
+"""S3 Vectorsインデックスへのベクトル登録・削除。
+metadataはfilterable=documentId、non-filterable=text / filename(architecture.md 8.3)。
+vector keyは`<documentId>#<チャンク番号>`とし、chat-fnのRetrieverが
+チャンク単位でRRFの名寄せに使う(app/rag/retriever.py)。
+"""
+
+from typing import Any
+
+import boto3
+
+# PutVectors / DeleteVectorsのAPI上限は500件。
+# 1ベクトルは1536次元 + チャンク本文を含み1リクエストが大きくなるため控えめにする
+MAX_VECTORS_PER_REQUEST = 100
+
+
+def vector_key(document_id: str, chunk_index: int) -> str:
+    return f"{document_id}#{chunk_index}"
+
+
+class VectorIndex:
+    def __init__(self, index_arn: str, client: Any | None = None) -> None:
+        self._index_arn = index_arn
+        self._client = client or boto3.client("s3vectors")
+
+    def put_chunks(
+        self,
+        *,
+        document_id: str,
+        filename: str,
+        chunks: list[str],
+        vectors: list[list[float]],
+    ) -> None:
+        """チャンクとベクトルを対応付けて登録する。同じkeyへの登録は上書きになる。"""
+        if len(chunks) != len(vectors):
+            raise ValueError("chunks and vectors must have the same length")
+
+        items = [
+            {
+                "key": vector_key(document_id, index),
+                "data": {"float32": vector},
+                "metadata": {
+                    "documentId": document_id,
+                    "text": chunk,
+                    "filename": filename,
+                },
+            }
+            for index, (chunk, vector) in enumerate(zip(chunks, vectors, strict=True))
+        ]
+        for batch in _batched(items):
+            self._client.put_vectors(indexArn=self._index_arn, vectors=batch)
+
+    def delete_keys(self, keys: list[str]) -> None:
+        for batch in _batched(keys):
+            self._client.delete_vectors(indexArn=self._index_arn, keys=batch)
+
+
+def _batched(items: list) -> list[list]:
+    return [
+        items[start : start + MAX_VECTORS_PER_REQUEST]
+        for start in range(0, len(items), MAX_VECTORS_PER_REQUEST)
+    ]

--- a/apps/backend/app/ingest_handler.py
+++ b/apps/backend/app/ingest_handler.py
@@ -1,22 +1,65 @@
-"""ingest-fn のエントリポイント
+"""ingest-fn のエントリポイント。
+
 Dockerfileの worker ターゲットで awslambdaric により呼び出される。
-SQSによってトリガーされる通常のLambdaハンドラーとして動作する（Web AdapterやFastAPIは不使用）。
-テキスト抽出 / チャンク分割 / Embedding / S3 Vectors への登録は後で実装予定。
-現時点では、ハンドラーは受信したメッセージのログ出力のみを行う。
+SQSによってトリガーされる通常のLambdaハンドラーとして動作する（LWAやFastAPIは不使用）。
+
+取込に失敗した場合はドキュメントをfailedにして例外を再送出する。
+SQSはbatchSize=1の為、そのメッセージだけが再試行され、maxReceiveCount(3)を超えるとDLQへ退避する。
 """
 
-import logging
+import json
 
-logger = logging.getLogger(__name__)
-# Lambdaの実行環境がすでにルートロガーにハンドラーを追加しているため、
-# logging.basicConfig() は効果がない（no-op）。そのため直接ログレベルを設定する。
-logger.setLevel(logging.INFO)
+from app.ingest.pipeline import get_ingest_pipeline
+from app.logger import logger
+from app.repositories.documents import DocumentStatusError
+
+FAILED_ALLOWED_FROM = ("processing", "failed", "ingested")
 
 
+# logger.inject_lambda_contextはLambda Powertools のデコレータで
+# Lambdaのコンテキスト情報(function_nameやLambdaランタイムが生成するaws_request_id等)を自動的にログに付与
+@logger.inject_lambda_context
 def handler(event, context):
+    """Records を取り出し1件ずつ_process_recordに渡して実行する関数"""
     records = event.get("Records", [])
-    logger.info("received %d ingest message(s)", len(records))
+    logger.info("received ingest message(s)", record_count=len(records))
     for record in records:
-        logger.info("messageId=%s body=%s", record.get("messageId"), record.get("body"))
-    # バッチの一部失敗用レスポンス形式。空の場合はすべてのレコードが成功したことを意味する。
-    return {"batchItemFailures": []}
+        _process_record(record)
+
+
+def _process_record(record: dict) -> None:
+    message = json.loads(record["body"])
+    document_id = message["documentId"]
+    user_id = message["userId"]
+    # api-fnが発番したRequest IDを引き継ぎ、取込完了までログを追跡する
+    logger.append_keys(request_id=message.get("requestId"), document_id=document_id)
+
+    pipeline = get_ingest_pipeline()
+    try:
+        chunk_count = pipeline.run(
+            document_id=document_id,
+            user_id=user_id,
+            s3_key=message["s3Key"],
+        )
+        logger.info("document ingest completed", chunk_count=chunk_count)
+    except Exception:
+        logger.exception("document ingest failed")
+        _mark_failed(pipeline, user_id=user_id, document_id=document_id)
+        raise
+    finally:
+        logger.remove_keys(["request_id", "document_id"])
+
+
+def _mark_failed(pipeline, *, user_id: str, document_id: str) -> None:
+    """
+    ドキュメントのステータスを failed に更新する処理
+    取込失敗のraiseを上書きしない為にステータス更新処理自体が失敗しても例外を外に漏らさない
+    """
+    try:
+        pipeline.repository.update_status(
+            user_id, document_id, "failed", allowed_from=FAILED_ALLOWED_FROM
+        )
+    except DocumentStatusError:
+        logger.warning("could not mark document as failed")
+    except Exception:
+        logger.exception("failed to update document status")

--- a/apps/backend/app/repositories/documents.py
+++ b/apps/backend/app/repositories/documents.py
@@ -80,21 +80,28 @@ class DocumentRepository:
         new_status: str,
         *,
         allowed_from: tuple[str, ...],
+        chunk_count: int | None = None,
     ) -> None:
         """条件付き更新でステータスを遷移させる。
 
         現在のステータスがallowed_from外の場合はDocumentStatusErrorを送出する。
+        chunk_countは取込完了時のみ指定し、再取込での余剰ベクトル削除に使う。
         """
+        expression = "SET #status = :status, updatedAt = :now"
+        values: dict = {
+            ":status": new_status,
+            ":now": datetime.now(UTC).isoformat(),
+        }
+        if chunk_count is not None:
+            expression += ", chunkCount = :chunkCount"
+            values[":chunkCount"] = chunk_count
         try:
             self._table.update_item(
                 Key={"PK": f"USER#{user_id}", "SK": f"DOC#{document_id}"},
-                UpdateExpression="SET #status = :status, updatedAt = :now",
+                UpdateExpression=expression,
                 ConditionExpression=Attr("status").is_in(list(allowed_from)),
                 ExpressionAttributeNames={"#status": "status"},
-                ExpressionAttributeValues={
-                    ":status": new_status,
-                    ":now": datetime.now(UTC).isoformat(),
-                },
+                ExpressionAttributeValues=values,
             )
         except self._table.meta.client.exceptions.ConditionalCheckFailedException:
             raise DocumentStatusError(

--- a/apps/backend/app/settings.py
+++ b/apps/backend/app/settings.py
@@ -6,10 +6,11 @@ from functools import lru_cache
 # 生成後に値を書き換えられないようにする
 @dataclass(frozen=True)
 class Settings:
+    # 関数ごとに必要な環境変数が異なるため、未設定でも空文字でフォールバックする
+    # (例: ingest-fnはHTTPを受けないためCognitoの設定を持たない)
     cognito_issuer: str
     cognito_client_id: str
     table_name: str
-    # 関数ごとに必要な環境変数が異なるため、未設定でも空文字でフォールバックする
     documents_bucket_name: str
     ingest_queue_url: str
     vector_index_arn: str
@@ -25,8 +26,8 @@ class Settings:
 @lru_cache
 def get_settings() -> Settings:
     return Settings(
-        cognito_issuer=os.environ["COGNITO_ISSUER"],
-        cognito_client_id=os.environ["COGNITO_CLIENT_ID"],
+        cognito_issuer=os.environ.get("COGNITO_ISSUER", ""),
+        cognito_client_id=os.environ.get("COGNITO_CLIENT_ID", ""),
         table_name=os.environ["TABLE_NAME"],
         documents_bucket_name=os.environ.get("DOCUMENTS_BUCKET_NAME", ""),
         ingest_queue_url=os.environ.get("INGEST_QUEUE_URL", ""),

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -31,13 +31,18 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "ruff>=0.15.22",
 ]
+# ingest-fn(Dockerfileのworkerターゲット)のドキュメント処理用。api-fn/chat-fnのイメージには入れない。
+# ローカル開発とテストでは取込処理を動かすため既定で入れる
+ingest = [
+    "pypdf>=6.0",
+]
 # ingest-fn(Dockerfileのworkerターゲット)専用。ネイティブ開発環境には入れない
 worker = [
     "awslambdaric>=3.1",
 ]
 
 [tool.uv]
-default-groups = ["dev", "chat"]
+default-groups = ["dev", "chat", "ingest"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -8,6 +8,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt import PyJWKClient
 from moto import mock_aws
 
+from app.ingest.pipeline import get_ingest_pipeline
 from app.rag.runtime import get_rag_runtime
 from app.settings import get_settings
 from app.ssm import get_parameter
@@ -51,6 +52,7 @@ def _clear_caches() -> None:
     get_settings.cache_clear()
     get_parameter.cache_clear()
     get_rag_runtime.cache_clear()
+    get_ingest_pipeline.cache_clear()
 
 
 @pytest.fixture(scope="session")

--- a/apps/backend/tests/factories.py
+++ b/apps/backend/tests/factories.py
@@ -15,6 +15,7 @@ def put_document(
     filename: str = "doc.pdf",
     status: str = "uploaded",
     created_at: str | None = None,
+    chunk_count: int | None = None,
 ) -> dict:
     now = created_at or datetime.now(UTC).isoformat()
     item = {
@@ -30,6 +31,9 @@ def put_document(
         "createdAt": now,
         "updatedAt": now,
     }
+    # 取込済みドキュメントのみが持つ属性
+    if chunk_count is not None:
+        item["chunkCount"] = chunk_count
     table.put_item(Item=item)
     return item
 

--- a/apps/backend/tests/ingest/test_chunking.py
+++ b/apps/backend/tests/ingest/test_chunking.py
@@ -1,0 +1,67 @@
+import pytest
+
+from app.ingest.chunking import CHUNK_OVERLAP, CHUNK_SIZE, split_text
+
+
+def test_short_text_becomes_single_chunk():
+    assert split_text("短い本文") == ["短い本文"]
+
+
+def test_empty_text_produces_no_chunks():
+    assert split_text("") == []
+    assert split_text("   \n\n  ") == []
+
+
+def test_every_chunk_fits_in_chunk_size():
+    text = "\n\n".join(f"段落{index}。" + "本文" * 100 for index in range(10))
+
+    chunks = split_text(text)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= CHUNK_SIZE for chunk in chunks)
+
+
+def test_prefers_paragraph_separator():
+    """chunk_sizeに収まる段落は、段落の途中で切られない。"""
+    paragraphs = [f"段落{index}" * 30 for index in range(6)]
+
+    chunks = split_text("\n\n".join(paragraphs), chunk_size=200, chunk_overlap=0)
+
+    for paragraph in paragraphs:
+        assert any(paragraph in chunk for chunk in chunks)
+
+
+def test_consecutive_chunks_overlap():
+    text = " ".join(f"word{index}" for index in range(200))
+
+    chunks = split_text(text, chunk_size=100, chunk_overlap=30)
+
+    assert len(chunks) > 1
+    # 末尾30文字程度が次のチャンクの先頭に現れる
+    assert chunks[1].split(" ")[0] in chunks[0]
+
+
+def test_splits_text_without_any_separator():
+    """区切り文字を持たない連続文字列も必ずchunk_size以内に収める。"""
+    chunks = split_text("あ" * 1200)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= CHUNK_SIZE for chunk in chunks)
+    assert "".join(chunks).count("あ") >= 1200
+
+
+def test_recombines_all_content_without_overlap():
+    text = "\n".join(f"行{index}" for index in range(50))
+
+    chunks = split_text(text, chunk_size=40, chunk_overlap=0)
+
+    assert "".join(chunks).replace("\n", "") == text.replace("\n", "")
+
+
+def test_default_settings_match_ported_pipeline():
+    assert (CHUNK_SIZE, CHUNK_OVERLAP) == (500, 50)
+
+
+def test_overlap_must_be_smaller_than_chunk_size():
+    with pytest.raises(ValueError):
+        split_text("本文", chunk_size=100, chunk_overlap=100)

--- a/apps/backend/tests/ingest/test_embeddings.py
+++ b/apps/backend/tests/ingest/test_embeddings.py
@@ -1,0 +1,95 @@
+import json
+
+import httpx
+import pytest
+
+from app.ingest.embeddings import (
+    COHERE_EMBED_URL,
+    EMBEDDING_DIMENSION,
+    MAX_TEXTS_PER_REQUEST,
+    CohereEmbedder,
+)
+
+MODEL = "embed-v4.0"
+
+
+def build_embedder(handler) -> tuple[CohereEmbedder, list[httpx.Request]]:
+    """Cohere APIを呼ばずにリクエスト内容を記録するembedderを組み立てる。"""
+    requests: list[httpx.Request] = []
+
+    def record(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler(request)
+
+    client = httpx.Client(transport=httpx.MockTransport(record))
+    return (
+        CohereEmbedder(api_key="test-key", model=MODEL, client=client),
+        requests,
+    )
+
+
+def respond_with_vectors(request: httpx.Request) -> httpx.Response:
+    texts = json.loads(request.content)["texts"]
+    return httpx.Response(
+        200,
+        json={"embeddings": {"float": [[0.1] * EMBEDDING_DIMENSION for _ in texts]}},
+    )
+
+
+def test_sends_search_document_request_to_cohere():
+    embedder, requests = build_embedder(respond_with_vectors)
+
+    vectors = embedder.embed_documents(["チャンク1", "チャンク2"])
+
+    assert len(vectors) == 2
+    assert all(len(vector) == EMBEDDING_DIMENSION for vector in vectors)
+    assert len(requests) == 1
+    request = requests[0]
+    assert str(request.url) == COHERE_EMBED_URL
+    assert request.headers["Authorization"] == "Bearer test-key"
+    payload = json.loads(request.content)
+    assert payload == {
+        "model": MODEL,
+        "texts": ["チャンク1", "チャンク2"],
+        # 検索側(search_query)と対になる取込側の指定
+        "input_type": "search_document",
+        "embedding_types": ["float"],
+        "output_dimension": EMBEDDING_DIMENSION,
+    }
+
+
+def test_splits_requests_by_api_batch_limit():
+    embedder, requests = build_embedder(respond_with_vectors)
+    texts = [f"チャンク{index}" for index in range(MAX_TEXTS_PER_REQUEST + 5)]
+
+    vectors = embedder.embed_documents(texts)
+
+    # 順序が保たれたまま全チャンク分のベクトルが返る
+    assert len(vectors) == len(texts)
+    assert len(requests) == 2
+
+
+def test_no_request_for_empty_input():
+    embedder, requests = build_embedder(respond_with_vectors)
+
+    assert embedder.embed_documents([]) == []
+    assert requests == []
+
+
+def test_raises_on_api_error():
+    """失敗は握りつぶさず、SQSの再試行とDLQ退避に委ねる。"""
+    embedder, _ = build_embedder(lambda request: httpx.Response(429, json={}))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        embedder.embed_documents(["チャンク"])
+
+
+def test_raises_when_response_count_does_not_match():
+    embedder, _ = build_embedder(
+        lambda request: httpx.Response(
+            200, json={"embeddings": {"float": [[0.1] * EMBEDDING_DIMENSION]}}
+        )
+    )
+
+    with pytest.raises(ValueError):
+        embedder.embed_documents(["チャンク1", "チャンク2"])

--- a/apps/backend/tests/ingest/test_extract.py
+++ b/apps/backend/tests/ingest/test_extract.py
@@ -1,0 +1,84 @@
+import pytest
+
+from app.ingest.extract import (
+    EmptyDocumentError,
+    UnsupportedFileTypeError,
+    extract_text,
+)
+
+
+def build_pdf(text: str) -> bytes:
+    """テキストを1つ持つ最小構成のPDFを組み立てる。
+
+    バイナリのフィクスチャをリポジトリに置かずにPDF抽出を検証するため、
+    xrefのオフセットまで含めて正しいPDFをその場で生成する。
+    """
+    content = f"BT /F1 12 Tf 20 100 Td ({text}) Tj ET\n".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+        b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        b"<< /Length "
+        + str(len(content)).encode()
+        + b" >>\nstream\n"
+        + content
+        + b"endstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n".encode() + body + b"\nendobj\n"
+
+    xref_offset = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode()
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    ).encode()
+    return bytes(out)
+
+
+def test_extracts_text_from_pdf():
+    text = extract_text(filename="設計書.pdf", body=build_pdf("Hello RAG"))
+
+    assert "Hello RAG" in text
+
+
+@pytest.mark.parametrize("filename", ["notes.md", "notes.markdown", "notes.txt"])
+def test_decodes_text_formats_as_utf8(filename):
+    assert extract_text(filename=filename, body="# 見出し".encode()) == "# 見出し"
+
+
+def test_replaces_invalid_utf8_instead_of_failing():
+    """1バイトの文字化けで取込全体を失敗させない。"""
+    text = extract_text(filename="notes.txt", body=b"ok \xff bytes")
+
+    assert text.startswith("ok ")
+    assert "bytes" in text
+
+
+def test_extension_is_case_insensitive():
+    assert extract_text(filename="NOTES.TXT", body=b"body") == "body"
+
+
+def test_rejects_unsupported_extension():
+    with pytest.raises(UnsupportedFileTypeError):
+        extract_text(filename="sheet.xlsx", body=b"anything")
+
+
+def test_rejects_file_without_extension():
+    with pytest.raises(UnsupportedFileTypeError):
+        extract_text(filename="README", body=b"anything")
+
+
+def test_rejects_document_without_text():
+    """画像だけのPDFなど、抽出結果が空のものは取込対象にしない。"""
+    with pytest.raises(EmptyDocumentError):
+        extract_text(filename="empty.txt", body=b"   \n\n  ")

--- a/apps/backend/tests/ingest/test_vectors.py
+++ b/apps/backend/tests/ingest/test_vectors.py
@@ -1,0 +1,117 @@
+import pytest
+
+from app.ingest.vectors import MAX_VECTORS_PER_REQUEST, VectorIndex, vector_key
+
+INDEX_ARN = (
+    "arn:aws:s3vectors:ap-northeast-1:123456789012:bucket/vectors/index/documents"
+)
+DIMENSION = 1536
+
+
+class StubS3VectorsClient:
+    def __init__(self) -> None:
+        self.put_calls: list[dict] = []
+        self.delete_calls: list[dict] = []
+
+    def put_vectors(self, **kwargs):
+        self.put_calls.append(kwargs)
+
+    def delete_vectors(self, **kwargs):
+        self.delete_calls.append(kwargs)
+
+
+@pytest.fixture
+def client():
+    return StubS3VectorsClient()
+
+
+def test_vector_key_matches_retriever_convention():
+    # chat-fn側のRRFはこのkeyでチャンクを名寄せする
+    assert vector_key("doc-1", 0) == "doc-1#0"
+
+
+def test_put_chunks_registers_metadata(client):
+    index = VectorIndex(INDEX_ARN, client=client)
+
+    index.put_chunks(
+        document_id="doc-1",
+        filename="設計書.pdf",
+        chunks=["本文1", "本文2"],
+        vectors=[[0.1] * DIMENSION, [0.2] * DIMENSION],
+    )
+
+    assert len(client.put_calls) == 1
+    call = client.put_calls[0]
+    assert call["indexArn"] == INDEX_ARN
+    assert call["vectors"] == [
+        {
+            "key": "doc-1#0",
+            "data": {"float32": [0.1] * DIMENSION},
+            "metadata": {
+                "documentId": "doc-1",
+                "text": "本文1",
+                "filename": "設計書.pdf",
+            },
+        },
+        {
+            "key": "doc-1#1",
+            "data": {"float32": [0.2] * DIMENSION},
+            "metadata": {
+                "documentId": "doc-1",
+                "text": "本文2",
+                "filename": "設計書.pdf",
+            },
+        },
+    ]
+
+
+def test_put_chunks_splits_into_api_sized_batches(client):
+    index = VectorIndex(INDEX_ARN, client=client)
+    count = MAX_VECTORS_PER_REQUEST + 1
+
+    index.put_chunks(
+        document_id="doc-1",
+        filename="doc.txt",
+        chunks=[f"本文{i}" for i in range(count)],
+        vectors=[[0.1] * DIMENSION for _ in range(count)],
+    )
+
+    assert [len(call["vectors"]) for call in client.put_calls] == [
+        MAX_VECTORS_PER_REQUEST,
+        1,
+    ]
+
+
+def test_put_chunks_rejects_mismatched_lengths(client):
+    index = VectorIndex(INDEX_ARN, client=client)
+
+    with pytest.raises(ValueError):
+        index.put_chunks(
+            document_id="doc-1",
+            filename="doc.txt",
+            chunks=["本文1", "本文2"],
+            vectors=[[0.1] * DIMENSION],
+        )
+
+
+def test_delete_keys_splits_into_api_sized_batches(client):
+    index = VectorIndex(INDEX_ARN, client=client)
+    keys = [vector_key("doc-1", i) for i in range(MAX_VECTORS_PER_REQUEST + 2)]
+
+    index.delete_keys(keys)
+
+    assert [len(call["keys"]) for call in client.delete_calls] == [
+        MAX_VECTORS_PER_REQUEST,
+        2,
+    ]
+    assert client.delete_calls[0]["indexArn"] == INDEX_ARN
+
+
+def test_no_api_call_for_empty_input(client):
+    index = VectorIndex(INDEX_ARN, client=client)
+
+    index.put_chunks(document_id="doc-1", filename="doc.txt", chunks=[], vectors=[])
+    index.delete_keys([])
+
+    assert client.put_calls == []
+    assert client.delete_calls == []

--- a/apps/backend/tests/test_ingest_handler.py
+++ b/apps/backend/tests/test_ingest_handler.py
@@ -1,0 +1,271 @@
+"""ingest-fnのSQSハンドラーの結合テスト。
+
+S3とDynamoDBはmoto、Cohere APIとS3 Vectorsはスタブへ差し替える。
+"""
+
+import json
+from types import SimpleNamespace
+
+import boto3
+import pytest
+
+from app.ingest.embeddings import EMBEDDING_DIMENSION
+from app.ingest.pipeline import IngestPipeline
+from app.ingest.vectors import VectorIndex
+from app.ingest_handler import handler
+from app.repositories.documents import DocumentRepository
+from tests.conftest import BUCKET_NAME, TABLE_NAME, VECTOR_INDEX_ARN
+from tests.factories import put_document
+from tests.ingest.test_vectors import StubS3VectorsClient
+
+USER_ID = "user-123"
+DOCUMENT_ID = "01JDOC0000000000000000000"
+FILENAME = "設計書.txt"
+S3_KEY = f"documents/{USER_ID}/{DOCUMENT_ID}/{FILENAME}"
+
+
+class StubEmbedder:
+    """Cohere APIを呼ばず、テキスト数ぶんの固定ベクトルを返す。"""
+
+    def __init__(self) -> None:
+        self.texts: list[str] = []
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        self.texts.extend(texts)
+        return [[0.1] * EMBEDDING_DIMENSION for _ in texts]
+
+
+@pytest.fixture
+def vectors_client():
+    return StubS3VectorsClient()
+
+
+@pytest.fixture
+def embedder():
+    return StubEmbedder()
+
+
+@pytest.fixture
+def pipeline(aws, monkeypatch, embedder, vectors_client):
+    """S3 / DynamoDBは実挙動(moto)のまま、外部APIだけスタブ化したpipelineを注入する。"""
+    pipeline = IngestPipeline(
+        bucket_name=BUCKET_NAME,
+        repository=DocumentRepository(TABLE_NAME),
+        embedder=embedder,
+        vector_index=VectorIndex(VECTOR_INDEX_ARN, client=vectors_client),
+        s3_client=boto3.client("s3"),
+    )
+    monkeypatch.setattr(
+        "app.ingest_handler.get_ingest_pipeline", lambda: pipeline, raising=True
+    )
+    return pipeline
+
+
+@pytest.fixture
+def lambda_context():
+    """Powertoolsのinject_lambda_contextが参照する属性だけを持つダミー。"""
+    return SimpleNamespace(
+        function_name="ingest-fn",
+        memory_limit_in_mb=1024,
+        invoked_function_arn=(
+            "arn:aws:lambda:ap-northeast-1:123456789012:function:ingest-fn"
+        ),
+        aws_request_id="lambda-request-id",
+    )
+
+
+def build_event(
+    *, document_id: str = DOCUMENT_ID, s3_key: str = S3_KEY, request_id: str = "req-1"
+) -> dict:
+    return {
+        "Records": [
+            {
+                "messageId": "message-1",
+                "body": json.dumps(
+                    {
+                        "documentId": document_id,
+                        "userId": USER_ID,
+                        "s3Key": s3_key,
+                        "requestId": request_id,
+                    },
+                    ensure_ascii=False,
+                ),
+            }
+        ]
+    }
+
+
+def upload(aws, body: bytes, key: str = S3_KEY) -> None:
+    aws.s3.put_object(Bucket=BUCKET_NAME, Key=key, Body=body)
+
+
+def get_document(aws) -> dict:
+    return aws.table.get_item(
+        Key={"PK": f"USER#{USER_ID}", "SK": f"DOC#{DOCUMENT_ID}"}
+    )["Item"]
+
+
+def test_registers_vectors_and_marks_document_ingested(
+    aws, pipeline, embedder, vectors_client, lambda_context
+):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+    )
+    upload(aws, "取込対象の本文".encode())
+
+    handler(build_event(), lambda_context)
+
+    assert embedder.texts == ["取込対象の本文"]
+    assert vectors_client.put_calls[0]["vectors"] == [
+        {
+            "key": f"{DOCUMENT_ID}#0",
+            "data": {"float32": [0.1] * EMBEDDING_DIMENSION},
+            "metadata": {
+                "documentId": DOCUMENT_ID,
+                "text": "取込対象の本文",
+                "filename": FILENAME,
+            },
+        }
+    ]
+    document = get_document(aws)
+    assert document["status"] == "ingested"
+    assert int(document["chunkCount"]) == 1
+
+
+def test_splits_long_document_into_multiple_vectors(
+    aws, pipeline, vectors_client, lambda_context
+):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+    )
+    upload(aws, ("段落。" * 400).encode())
+
+    handler(build_event(), lambda_context)
+
+    keys = [vector["key"] for vector in vectors_client.put_calls[0]["vectors"]]
+    assert len(keys) > 1
+    assert keys[0] == f"{DOCUMENT_ID}#0"
+    assert int(get_document(aws)["chunkCount"]) == len(keys)
+
+
+def test_reingest_deletes_leftover_vectors(
+    aws, pipeline, vectors_client, lambda_context
+):
+    """再取込でチャンク数が減った場合、余った古いベクトルを削除する。"""
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+        chunk_count=4,
+    )
+    upload(aws, "短くなった本文".encode())
+
+    handler(build_event(), lambda_context)
+
+    assert vectors_client.delete_calls == [
+        {
+            "indexArn": VECTOR_INDEX_ARN,
+            "keys": [f"{DOCUMENT_ID}#1", f"{DOCUMENT_ID}#2", f"{DOCUMENT_ID}#3"],
+        }
+    ]
+    assert int(get_document(aws)["chunkCount"]) == 1
+
+
+def test_reingest_without_leftovers_does_not_delete(
+    aws, pipeline, vectors_client, lambda_context
+):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+        chunk_count=1,
+    )
+    upload(aws, "同じくらいの本文".encode())
+
+    handler(build_event(), lambda_context)
+
+    assert vectors_client.delete_calls == []
+
+
+def test_marks_failed_and_reraises_when_file_is_missing(
+    aws, pipeline, lambda_context, vectors_client
+):
+    """例外を再送出することでSQSが再試行し、最終的にDLQへ退避する。"""
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+    )
+
+    with pytest.raises(Exception):
+        handler(build_event(), lambda_context)
+
+    assert get_document(aws)["status"] == "failed"
+    assert vectors_client.put_calls == []
+
+
+def test_marks_failed_for_unsupported_file_type(aws, pipeline, lambda_context):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename="sheet.xlsx",
+        status="processing",
+    )
+    upload(aws, b"binary", key=f"documents/{USER_ID}/{DOCUMENT_ID}/sheet.xlsx")
+
+    with pytest.raises(Exception):
+        handler(
+            build_event(s3_key=f"documents/{USER_ID}/{DOCUMENT_ID}/sheet.xlsx"),
+            lambda_context,
+        )
+
+    assert get_document(aws)["status"] == "failed"
+
+
+def test_marks_failed_when_embedding_api_fails(
+    aws, pipeline, embedder, lambda_context, monkeypatch
+):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+    )
+    upload(aws, "本文".encode())
+
+    def fail(texts):
+        raise RuntimeError("cohere is unavailable")
+
+    monkeypatch.setattr(embedder, "embed_documents", fail)
+
+    with pytest.raises(RuntimeError):
+        handler(build_event(), lambda_context)
+
+    assert get_document(aws)["status"] == "failed"
+
+
+def test_unknown_document_raises_without_creating_item(aws, pipeline, lambda_context):
+    """DynamoDBに存在しないドキュメントのメッセージでもfailed更新で新規作成しない。"""
+    with pytest.raises(Exception):
+        handler(build_event(), lambda_context)
+
+    response = aws.table.get_item(
+        Key={"PK": f"USER#{USER_ID}", "SK": f"DOC#{DOCUMENT_ID}"}
+    )
+    assert "Item" not in response

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -99,6 +99,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+ingest = [
+    { name = "pypdf" },
+]
 worker = [
     { name = "awslambdaric" },
 ]
@@ -129,6 +132,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.22" },
 ]
+ingest = [{ name = "pypdf", specifier = ">=6.0" }]
 worker = [{ name = "awslambdaric", specifier = ">=3.1" }]
 
 [[package]]
@@ -1220,6 +1224,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -162,7 +162,8 @@ export class AppStack extends cdk.Stack {
           DOCUMENTS_BUCKET_NAME: dataStack.documentsBucket.bucketName,
           VECTOR_BUCKET_ARN: dataStack.vectorBucket.attrVectorBucketArn,
           VECTOR_INDEX_ARN: dataStack.vectorIndex.attrIndexArn,
-          OPENAI_API_KEY_PARAMETER_NAME,
+          // Embeddingはchat-fnの検索側と同じCohereモデルを使うため、OpenAIキーは不要
+          COHERE_API_KEY_PARAMETER_NAME,
           POWERTOOLS_SERVICE_NAME: "ingest",
           POWERTOOLS_LOG_LEVEL: "INFO",
         },
@@ -181,14 +182,13 @@ export class AppStack extends cdk.Stack {
         actions: [
           "s3vectors:GetIndex",
           "s3vectors:PutVectors",
-          // 再取込時の既存ベクトル削除用
-          "s3vectors:ListVectors",
+          // 再取込でチャンク数が減ったときの余剰ベクトル削除用
           "s3vectors:DeleteVectors",
         ],
         resources: [dataStack.vectorIndex.attrIndexArn],
       }),
     );
-    openaiApiKeyParameter.grantRead(this.ingestFunction);
+    cohereApiKeyParameter.grantRead(this.ingestFunction);
 
     new cdk.CfnOutput(this, "ApiFunctionUrl", {
       value: this.apiFunctionUrl.url,

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -101,7 +101,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:5a7cabbd43d6223219e8209b77e90fe696d0fc3c8b832dfe99961fac5a2df0c1",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:4af32d07c7c0b48202346fd0a9638bceda3111866f3183c610f19beb0ae19311",
           },
         },
         "Environment": {
@@ -328,7 +328,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bb651d64ff61c2784e3724db87531891b53746b4822015d502447aeb63e890f3",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:131775ebd5146b04bb98bc6c1e424b787447294a4b0af70a148f86a5336d3a28",
           },
         },
         "Environment": {
@@ -586,15 +586,15 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:cda9f0e63a86fa5decd6ea2155ee8ed204371af12bffffdcf66caabec8840135",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e6f66cd72e10edd7f6c0b92d9e65e728e4938d0920d5c68fe97a30b230d94ad3",
           },
         },
         "Environment": {
           "Variables": {
+            "COHERE_API_KEY_PARAMETER_NAME": "/event-driven-rag/cohere-api-key",
             "DOCUMENTS_BUCKET_NAME": {
               "Fn::ImportValue": "TestDataStack:ExportsOutputRefDocumentsBucket9EC9DEB9131399C0",
             },
-            "OPENAI_API_KEY_PARAMETER_NAME": "/event-driven-rag/openai-api-key",
             "POWERTOOLS_LOG_LEVEL": "INFO",
             "POWERTOOLS_SERVICE_NAME": "ingest",
             "TABLE_NAME": {
@@ -750,7 +750,6 @@ exports[`スナップショット 1`] = `
               "Action": [
                 "s3vectors:GetIndex",
                 "s3vectors:PutVectors",
-                "s3vectors:ListVectors",
                 "s3vectors:DeleteVectors",
               ],
               "Effect": "Allow",
@@ -782,7 +781,7 @@ exports[`スナップショット 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/event-driven-rag/openai-api-key",
+                    ":parameter/event-driven-rag/cohere-api-key",
                   ],
                 ],
               },

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -101,7 +101,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:4af32d07c7c0b48202346fd0a9638bceda3111866f3183c610f19beb0ae19311",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:285f14c6565f71448dd235d42f0cf06a6aeeb5a7981276b797fb234971b2e3d1",
           },
         },
         "Environment": {
@@ -328,7 +328,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:131775ebd5146b04bb98bc6c1e424b787447294a4b0af70a148f86a5336d3a28",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:ebea902b1f87590e4dac3e20140b2f5524fa61ee9f198d880e6cbb22e451187f",
           },
         },
         "Environment": {
@@ -586,7 +586,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:e6f66cd72e10edd7f6c0b92d9e65e728e4938d0920d5c68fe97a30b230d94ad3",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:1b55ae7c897068209c1d048353f976540a53d8b8731ada65ee7f0f5cc577a8d2",
           },
         },
         "Environment": {

--- a/cdk/test/app-stack.test.ts
+++ b/cdk/test/app-stack.test.ts
@@ -87,8 +87,11 @@ describe('Lambda', () => {
     expect(fn.Properties.Timeout).toBe(600);
     const env = fn.Properties.Environment.Variables;
     expect(env).not.toHaveProperty('AWS_LWA_INVOKE_MODE');
-    expect(env.OPENAI_API_KEY_PARAMETER_NAME).toBe(OPENAI_API_KEY_PARAMETER_NAME);
-    expect(env).not.toHaveProperty('COHERE_API_KEY_PARAMETER_NAME');
+    // Embeddingはchat-fnの検索側と同じCohereモデルを使うため、OpenAIキーは持たない
+    expect(env.COHERE_API_KEY_PARAMETER_NAME).toBe(COHERE_API_KEY_PARAMETER_NAME);
+    expect(env).not.toHaveProperty('OPENAI_API_KEY_PARAMETER_NAME');
+    expect(env).toHaveProperty('DOCUMENTS_BUCKET_NAME');
+    expect(env).toHaveProperty('VECTOR_INDEX_ARN');
   });
 
   test('3つのLambdaはそれぞれ別ターゲットのイメージを使う', () => {
@@ -163,7 +166,6 @@ describe('IAM', () => {
       (s) => Array.isArray(s.Action) && s.Action.includes('s3vectors:PutVectors'),
     );
     expect(statement).toBeDefined();
-    expect(statement.Action).toContain('s3vectors:ListVectors');
     expect(statement.Action).toContain('s3vectors:DeleteVectors');
   });
 
@@ -171,7 +173,7 @@ describe('IAM', () => {
     const statements = policyStatements().filter(
       (s) => Array.isArray(s.Action) && s.Action.includes('ssm:GetParameter'),
     );
-    // chat-fn(openai + cohere)とingest-fn(openai)
+    // chat-fn(openai + cohere)とingest-fn(cohere)
     expect(statements.length).toBeGreaterThanOrEqual(2);
     expect(JSON.stringify(statements)).toContain(
       `parameter${OPENAI_API_KEY_PARAMETER_NAME}`,


### PR DESCRIPTION
build(backend): add ingest dependency group with pypdf to the worker image

feat(backend): implement the ingest pipeline for ingest-fn

feat(cdk): switch ingest-fn to the Cohere API key

fix(backend): exclude nested bytecode caches from the image asset

Closes #12 