### PR TITLE
Add the document management screen with upload and ingest

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,20 +1,25 @@
 import { Route, Routes } from "react-router-dom";
 import { RequireAuth } from "./auth/RequireAuth";
+import { Layout } from "./components/Layout";
 import { AuthCallback } from "./pages/AuthCallback";
+import { Documents } from "./pages/Documents";
 import { Home } from "./pages/Home";
 
 function App() {
   return (
     <Routes>
+      {/* 認証コールバック処理中は未認証状態のため、RequireAuth配下に置くとリダイレクトループが発生する */}
       <Route path="/auth/callback" element={<AuthCallback />} />
       <Route
-        path="/"
         element={
           <RequireAuth>
-            <Home />
+            <Layout />
           </RequireAuth>
         }
-      />
+      >
+        <Route path="/" element={<Home />} />
+        <Route path="/documents" element={<Documents />} />
+      </Route>
     </Routes>
   );
 }

--- a/apps/frontend/src/api/documents.ts
+++ b/apps/frontend/src/api/documents.ts
@@ -1,0 +1,78 @@
+import axios from "axios";
+import { api } from "./client";
+
+export type DocumentStatus =
+  "uploading" | "uploaded" | "processing" | "ingested" | "failed";
+
+export interface DocumentSummary {
+  documentId: string;
+  userId: string;
+  filename: string;
+  status: DocumentStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface CreateUploadUrlResponse {
+  documentId: string;
+  uploadUrl: string;
+}
+
+interface DownloadUrlResponse {
+  downloadUrl: string;
+  filename: string;
+}
+
+/** 全ユーザー横断のドキュメント一覧を新しい順で取得する。 */
+export async function listDocuments(): Promise<DocumentSummary[]> {
+  const res = await api.get<DocumentSummary[]>("/documents");
+  return res.data;
+}
+
+/** uploading状態でドキュメントを登録し、アップロード用の署名付きPUT URLを取得する。 */
+export async function createUploadUrl(
+  filename: string,
+  contentType: string,
+): Promise<CreateUploadUrlResponse> {
+  const res = await api.post<CreateUploadUrlResponse>("/documents/upload-url", {
+    filename,
+    contentType,
+  });
+  return res.data;
+}
+
+/** 署名付きURLでS3へ直接アップロードする。
+ *
+ * apiインスタンスはAuthorizationヘッダーを付与するインターセプタを持ち、
+ * 署名付きURLへ送ると認証方式の重複でS3が400を返す為、ここでは素のaxiosを使う。
+ * Content-Typeは署名に含まれているので、URL発行時と同じ値を送る必要がある。
+ */
+export async function putToS3(
+  uploadUrl: string,
+  file: File,
+  contentType: string,
+): Promise<void> {
+  await axios.put(uploadUrl, file, {
+    headers: { "Content-Type": contentType },
+  });
+}
+
+/** アップロード完了を登録し、ステータスをuploadedにする。 */
+export async function completeUpload(documentId: string): Promise<void> {
+  await api.post(`/documents/${documentId}/complete`);
+}
+
+/** 取込をキューへ送り、ステータスをprocessingにする。 */
+export async function startIngest(documentId: string): Promise<void> {
+  await api.post(`/documents/${documentId}/ingest`);
+}
+
+/** 原本閲覧用の署名付きGET URLを取得する。 */
+export async function fetchDownloadUrl(
+  documentId: string,
+): Promise<DownloadUrlResponse> {
+  const res = await api.get<DownloadUrlResponse>(
+    `/documents/${documentId}/download-url`,
+  );
+  return res.data;
+}

--- a/apps/frontend/src/components/DocumentTable.css
+++ b/apps/frontend/src/components/DocumentTable.css
@@ -1,0 +1,83 @@
+.document-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 15px;
+
+  th,
+  td {
+    text-align: left;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+  }
+
+  th {
+    font-weight: 500;
+    font-size: 14px;
+    color: var(--text);
+    border-bottom-width: 2px;
+    white-space: nowrap;
+  }
+
+  tbody tr:hover {
+    background: var(--social-bg);
+  }
+
+  .filename {
+    color: var(--text-h);
+    word-break: break-all;
+  }
+
+  .updated-at {
+    font-family: var(--mono);
+    font-size: 14px;
+    white-space: nowrap;
+  }
+
+  .actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  .actions button {
+    font: inherit;
+    font-size: 14px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      border-color 0.2s,
+      color 0.2s;
+
+    &:hover:not(:disabled) {
+      border-color: var(--accent-border);
+      color: var(--text-h);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    &.primary {
+      border-color: transparent;
+      background: var(--accent-bg);
+      color: var(--accent);
+
+      &:hover:not(:disabled) {
+        border-color: var(--accent-border);
+        color: var(--accent);
+      }
+    }
+  }
+}

--- a/apps/frontend/src/components/DocumentTable.tsx
+++ b/apps/frontend/src/components/DocumentTable.tsx
@@ -1,0 +1,80 @@
+import type { DocumentSummary } from "../api/documents";
+import { StatusBadge } from "./StatusBadge";
+import "./DocumentTable.css";
+
+interface DocumentTableProps {
+  documents: DocumentSummary[];
+  /** サインイン中のユーザーのsub。取込は本人のドキュメントにしか実行できない */
+  currentUserId: string | undefined;
+  onOpen: (documentId: string) => void;
+  onIngest: (documentId: string) => void;
+  openingId: string | null;
+  ingestingId: string | null;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  dateStyle: "short",
+  timeStyle: "short",
+});
+
+// バックエンドのステータス遷移(uploaded|failed → processing)に合わせる
+const INGESTABLE = ["uploaded", "failed"];
+
+export function DocumentTable({
+  documents,
+  currentUserId,
+  onOpen,
+  onIngest,
+  openingId,
+  ingestingId,
+}: DocumentTableProps) {
+  return (
+    <table className="document-table">
+      <thead>
+        <tr>
+          <th scope="col">ファイル名</th>
+          <th scope="col">状態</th>
+          <th scope="col">更新日時</th>
+          <th scope="col">操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {documents.map((document) => {
+          const canIngest =
+            document.userId === currentUserId &&
+            INGESTABLE.includes(document.status);
+          return (
+            <tr key={document.documentId}>
+              <td className="filename">{document.filename}</td>
+              <td>
+                <StatusBadge status={document.status} />
+              </td>
+              <td className="updated-at">
+                {dateFormatter.format(new Date(document.updatedAt))}
+              </td>
+              <td className="actions">
+                <button
+                  type="button"
+                  onClick={() => onOpen(document.documentId)}
+                  disabled={openingId === document.documentId}
+                >
+                  開く
+                </button>
+                {canIngest && (
+                  <button
+                    type="button"
+                    className="primary"
+                    onClick={() => onIngest(document.documentId)}
+                    disabled={ingestingId === document.documentId}
+                  >
+                    取込開始
+                  </button>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/frontend/src/components/Layout.css
+++ b/apps/frontend/src/components/Layout.css
@@ -1,0 +1,99 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-width: 0;
+}
+
+.layout-header {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 12px 32px;
+  border-bottom: 1px solid var(--border);
+
+  @media (max-width: 1024px) {
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 12px 20px;
+  }
+}
+
+.layout-brand {
+  font-family: var(--heading);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--text-h);
+  white-space: nowrap;
+}
+
+.layout-nav {
+  display: flex;
+  gap: 8px;
+
+  a {
+    font-size: 16px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+    transition:
+      background 0.2s,
+      color 0.2s;
+
+    &:hover {
+      background: var(--social-bg);
+      color: var(--text-h);
+    }
+
+    &.active {
+      color: var(--accent);
+      background: var(--accent-bg);
+    }
+  }
+}
+
+/* ユーザー名とサインアウトをヘッダー右端へ寄せる */
+.layout-user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-left: auto;
+  font-size: 16px;
+
+  button {
+    font: inherit;
+    font-size: 15px;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      border-color 0.2s,
+      color 0.2s;
+
+    &:hover {
+      border-color: var(--accent-border);
+      color: var(--text-h);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.layout-main {
+  flex-grow: 1;
+  min-width: 0;
+  padding: 24px 32px 48px;
+
+  @media (max-width: 1024px) {
+    padding: 20px 20px 32px;
+  }
+}

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -1,0 +1,37 @@
+import { useAuth } from "react-oidc-context";
+import { NavLink, Outlet } from "react-router-dom";
+import { redirectToCognitoLogout } from "../auth/userManager";
+import "./Layout.css";
+
+export function Layout() {
+  const auth = useAuth();
+
+  const handleSignOut = async () => {
+    // localStorageのトークンを破棄してからHosted UIのセッションを破棄する
+    await auth.removeUser();
+    redirectToCognitoLogout();
+  };
+
+  return (
+    <div className="layout">
+      <header className="layout-header">
+        <span className="layout-brand">Event Driven RAG</span>
+        <nav className="layout-nav">
+          <NavLink to="/" end>
+            チャット
+          </NavLink>
+          <NavLink to="/documents">ドキュメント</NavLink>
+        </nav>
+        <div className="layout-user">
+          <span>{auth.user?.profile.name}</span>
+          <button type="button" onClick={() => void handleSignOut()}>
+            サインアウト
+          </button>
+        </div>
+      </header>
+      <main className="layout-main">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/StatusBadge.css
+++ b/apps/frontend/src/components/StatusBadge.css
@@ -1,0 +1,52 @@
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  line-height: 1;
+  padding: 5px 10px;
+  border-radius: 999px;
+  white-space: nowrap;
+  color: var(--status-color);
+  border: 1px solid currentColor;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-uploading {
+  --status-color: var(--status-neutral);
+}
+.status-uploaded {
+  --status-color: var(--status-info);
+}
+.status-processing {
+  --status-color: var(--status-progress);
+}
+.status-ingested {
+  --status-color: var(--status-success);
+}
+.status-failed {
+  --status-color: var(--status-danger);
+}
+
+/* 取込中は処理が進んでいることが分かるように点滅させる */
+.status-processing .status-dot {
+  animation: status-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes status-pulse {
+  50% {
+    opacity: 0.25;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-processing .status-dot {
+    animation: none;
+  }
+}

--- a/apps/frontend/src/components/StatusBadge.tsx
+++ b/apps/frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,19 @@
+import type { DocumentStatus } from "../api/documents";
+import "./StatusBadge.css";
+
+const LABELS: Record<DocumentStatus, string> = {
+  uploading: "アップロード中",
+  uploaded: "未取込",
+  processing: "取込中",
+  ingested: "取込済",
+  failed: "失敗",
+};
+
+export function StatusBadge({ status }: { status: DocumentStatus }) {
+  return (
+    <span className={`status-badge status-${status}`}>
+      <span className="status-dot" aria-hidden="true" />
+      {LABELS[status] ?? status}
+    </span>
+  );
+}

--- a/apps/frontend/src/components/UploadForm.css
+++ b/apps/frontend/src/components/UploadForm.css
@@ -1,0 +1,98 @@
+.upload-form {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 24px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--social-bg);
+
+  button[type="submit"] {
+    font: inherit;
+    font-size: 15px;
+    padding: 7px 16px;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    background: var(--accent-bg);
+    color: var(--accent);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.2s;
+
+    &:hover:not(:disabled) {
+      border-color: var(--accent-border);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.file-picker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  cursor: pointer;
+
+  /* 見た目だけ隠し、キーボードのフォーカス対象としては残す */
+  input[type="file"] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  &:has(input:disabled) {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}
+
+.file-picker-button {
+  font-size: 15px;
+  padding: 7px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-h);
+  white-space: nowrap;
+  transition: border-color 0.2s;
+
+  .file-picker:hover:not(:has(input:disabled)) & {
+    border-color: var(--accent-border);
+  }
+
+  /* 隠したinputがフォーカスされたら、見た目上のボタン側に枠を出す */
+  .file-picker:focus-within & {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+}
+
+.file-name {
+  font-size: 15px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.upload-hint {
+  font-size: 14px;
+  color: var(--text);
+  margin-left: auto;
+}

--- a/apps/frontend/src/components/UploadForm.tsx
+++ b/apps/frontend/src/components/UploadForm.tsx
@@ -1,0 +1,50 @@
+import { useRef, useState } from "react";
+import { ACCEPTED_EXTENSIONS } from "../lib/fileTypes";
+import "./UploadForm.css";
+
+interface UploadFormProps {
+  /** アップロードを実行し、成功したらtrueを返す(失敗時のエラー表示は呼び出し側が行う) */
+  onUpload: (file: File) => Promise<boolean>;
+  isUploading: boolean;
+}
+
+export function UploadForm({ onUpload, isUploading }: UploadFormProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!file) return;
+    // 失敗時はやり直せるよう選択状態を残し、成功時だけクリアする
+    if (await onUpload(file)) {
+      setFile(null);
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  return (
+    <form className="upload-form" onSubmit={(e) => void handleSubmit(e)}>
+      {/* input[type=file]のボタン文言はブラウザのUIで変更できない為、
+          inputは視覚的に隠し(キーボード操作の為フォーカスは残す)、labelを見た目上のボタンにする */}
+      <label className="file-picker">
+        <input
+          ref={inputRef}
+          type="file"
+          accept={ACCEPTED_EXTENSIONS.join(",")}
+          disabled={isUploading}
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <span className="file-picker-button">ファイルを選択</span>
+        <span className="file-name">
+          {file ? file.name : "ファイルが選択されていません"}
+        </span>
+      </label>
+      <button type="submit" disabled={!file || isUploading}>
+        {isUploading ? "アップロード中…" : "アップロード"}
+      </button>
+      <span className="upload-hint">
+        対応形式: {ACCEPTED_EXTENSIONS.join(" / ")}
+      </span>
+    </form>
+  );
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -8,6 +8,12 @@
   --accent-bg: rgba(170, 59, 255, 0.1);
   --accent-border: rgba(170, 59, 255, 0.5);
   --social-bg: rgba(244, 243, 236, 0.5);
+  /* ドキュメントのステータス表示とエラー表示に使う */
+  --status-neutral: #6b7280;
+  --status-info: #2563eb;
+  --status-progress: #b45309;
+  --status-success: #15803d;
+  --status-danger: #b91c1c;
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 
@@ -41,6 +47,11 @@
     --accent-bg: rgba(192, 132, 252, 0.15);
     --accent-border: rgba(192, 132, 252, 0.5);
     --social-bg: rgba(47, 48, 58, 0.5);
+    --status-neutral: #9ca3af;
+    --status-info: #60a5fa;
+    --status-progress: #fbbf24;
+    --status-success: #4ade80;
+    --status-danger: #f87171;
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
   }
@@ -54,7 +65,7 @@
   width: 1126px;
   max-width: 100%;
   margin: 0 auto;
-  text-align: center;
+  text-align: left;
   border-inline: 1px solid var(--border);
   min-height: 100svh;
   display: flex;

--- a/apps/frontend/src/lib/errors.ts
+++ b/apps/frontend/src/lib/errors.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+
+/** APIエラーを画面表示用の日本語メッセージへ変換する。
+ *
+ * FastAPIのHTTPExceptionは{"detail": "..."}を返す為、あれば補足として添える。
+ */
+export function toErrorMessage(error: unknown, fallback: string): string {
+  if (!axios.isAxiosError(error)) {
+    return fallback;
+  }
+  const status = error.response?.status;
+  if (status === 401 || status === 403) {
+    return "認証の有効期限が切れた可能性があります。ページを再読み込みしてください。";
+  }
+  if (status === 404) {
+    return "対象のドキュメントが見つかりません。一覧を再取得してください。";
+  }
+  if (status === 409) {
+    return "ドキュメントの状態が変わっています。一覧を再取得しました。";
+  }
+  if (!error.response) {
+    return `${fallback}（サーバーに接続できませんでした）`;
+  }
+  const detail = (error.response.data as { detail?: unknown } | undefined)
+    ?.detail;
+  return typeof detail === "string" ? `${fallback}（${detail}）` : fallback;
+}

--- a/apps/frontend/src/lib/fileTypes.ts
+++ b/apps/frontend/src/lib/fileTypes.ts
@@ -1,0 +1,30 @@
+/** アップロード可能なファイル形式の判定とContent-Typeの決定。
+ *
+ * 対応形式はバックエンドのテキスト抽出(app/ingest/extract.py)に合わせる。
+ */
+
+// input[type=file]のaccept属性にもそのまま渡す
+export const ACCEPTED_EXTENSIONS = [".pdf", ".md", ".markdown", ".txt"];
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".pdf": "application/pdf",
+  // text/markdownはブラウザが表示せずダウンロードしてしまう為、原本閲覧のできるtext/plainで保存する。
+  // バックエンドはContent-Typeではなく拡張子で形式を判定するので取込結果は変わらない
+  ".md": "text/plain; charset=utf-8",
+  ".markdown": "text/plain; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+function extensionOf(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  return dot === -1 ? "" : filename.slice(dot).toLowerCase();
+}
+
+/** 対応形式ならContent-Typeを、非対応ならnullを返す。
+ *
+ * FileオブジェクトのtypeはMarkdownで空文字になるなどブラウザ依存の為、拡張子から決める。
+ * 署名付きURLの発行時とPUT時で同じ値を使わないと署名が一致しない。
+ */
+export function contentTypeFor(filename: string): string | null {
+  return CONTENT_TYPES[extensionOf(filename)] ?? null;
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
@@ -11,12 +12,28 @@ const onSigninCallback = () => {
   window.history.replaceState({}, document.title, window.location.pathname);
 };
 
+// アプリ全体で共有するキャッシュ。再生成するとキャッシュが失われる為モジュールスコープに置く
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // 4xxを何度も投げ直さない
+      retry: 1,
+      staleTime: 30_000,
+      // 別タブ→元タブに戻った時に自動で再フェッチしない
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 createRoot(document.getElementById("root")!).render(
+  // Provideで囲み、Contextをアプリ全体で利用可能にする
   <StrictMode>
     <AuthProvider userManager={userManager} onSigninCallback={onSigninCallback}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
     </AuthProvider>
   </StrictMode>,
 );

--- a/apps/frontend/src/pages/Documents.css
+++ b/apps/frontend/src/pages/Documents.css
@@ -1,0 +1,45 @@
+.documents {
+  .page-title {
+    font-size: 28px;
+    letter-spacing: -0.3px;
+    margin: 0 0 20px;
+  }
+
+  .alert {
+    padding: 12px 16px;
+    margin-bottom: 16px;
+    border-radius: 8px;
+    border: 1px solid var(--status-danger);
+    color: var(--status-danger);
+    font-size: 15px;
+  }
+
+  .placeholder {
+    padding: 32px 16px;
+    font-size: 15px;
+    color: var(--text);
+    text-align: center;
+
+    button {
+      font: inherit;
+      font-size: 14px;
+      margin-left: 8px;
+      padding: 6px 12px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text);
+      cursor: pointer;
+
+      &:hover {
+        border-color: var(--accent-border);
+        color: var(--text-h);
+      }
+    }
+  }
+
+  /* 画面が狭いときはテーブルだけを横スクロールさせ、ページ全体は横に伸ばさない */
+  .table-scroll {
+    overflow-x: auto;
+  }
+}

--- a/apps/frontend/src/pages/Documents.tsx
+++ b/apps/frontend/src/pages/Documents.tsx
@@ -1,0 +1,164 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useAuth } from "react-oidc-context";
+import {
+  completeUpload,
+  createUploadUrl,
+  fetchDownloadUrl,
+  listDocuments,
+  putToS3,
+  startIngest,
+} from "../api/documents";
+import { DocumentTable } from "../components/DocumentTable";
+import { UploadForm } from "../components/UploadForm";
+import { toErrorMessage } from "../lib/errors";
+import { ACCEPTED_EXTENSIONS, contentTypeFor } from "../lib/fileTypes";
+import "./Documents.css";
+
+const DOCUMENTS_QUERY_KEY = ["documents"];
+// 取込はSQS経由の非同期処理の為、完了をポーリングで待つ
+const POLL_INTERVAL_MS = 3000;
+
+export function Documents() {
+  const auth = useAuth();
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+  const [openingId, setOpeningId] = useState<string | null>(null);
+
+  const invalidateDocuments = () =>
+    queryClient.invalidateQueries({ queryKey: DOCUMENTS_QUERY_KEY });
+
+  const documentsQuery = useQuery({
+    queryKey: DOCUMENTS_QUERY_KEY,
+    queryFn: listDocuments,
+    // 取込中の行があればキャッシュを定期的に更新する。
+    refetchInterval: (query) =>
+      query.state.data?.some((document) => document.status === "processing")
+        ? POLL_INTERVAL_MS
+        : false,
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: async ({
+      file,
+      contentType,
+    }: {
+      file: File;
+      contentType: string;
+    }) => {
+      const { documentId, uploadUrl } = await createUploadUrl(
+        file.name,
+        contentType,
+      );
+      await putToS3(uploadUrl, file, contentType);
+      await completeUpload(documentId);
+    },
+    onSuccess: () => void invalidateDocuments(),
+    onError: (e) => setError(toErrorMessage(e, "アップロードに失敗しました")),
+  });
+
+  const ingestMutation = useMutation({
+    mutationFn: startIngest,
+    onSuccess: () => void invalidateDocuments(),
+    onError: (e) => {
+      setError(toErrorMessage(e, "取込の開始に失敗しました"));
+      // 他の操作と競合した場合に備え、最新のステータスを取り直す
+      void invalidateDocuments();
+    },
+  });
+
+  const handleUpload = async (file: File) => {
+    setError(null);
+    const contentType = contentTypeFor(file.name);
+    if (!contentType) {
+      // 非対応形式はS3へ送る前に弾き、uploadingのまま残るドキュメントを作らない
+      setError(
+        `対応していない形式です。${ACCEPTED_EXTENSIONS.join(" / ")}のいずれかを選択してください`,
+      );
+      return false;
+    }
+    try {
+      await uploadMutation.mutateAsync({ file, contentType });
+      return true;
+    } catch {
+      return false; // エラー表示はonErrorで行う
+    }
+  };
+
+  const handleIngest = (documentId: string) => {
+    setError(null);
+    ingestMutation.mutate(documentId);
+  };
+
+  const handleOpen = async (documentId: string) => {
+    setError(null);
+    // await後のwindow.openはポップアップブロックの対象になる為、クリック直後に空タブを開く
+    const tab = window.open("", "_blank");
+    // 原本のContent-Type次第ではタブ内でスクリプトが動く為、開いた側への参照を切る
+    if (tab) tab.opener = null;
+    setOpeningId(documentId);
+    try {
+      const { downloadUrl } = await fetchDownloadUrl(documentId);
+      if (tab) {
+        tab.location.href = downloadUrl;
+      } else {
+        setError(
+          "別タブを開けませんでした。ブラウザのポップアップ設定を確認してください",
+        );
+      }
+    } catch (e) {
+      tab?.close();
+      setError(toErrorMessage(e, "原本の取得に失敗しました"));
+    } finally {
+      setOpeningId(null);
+    }
+  };
+
+  return (
+    <div className="documents">
+      <h1 className="page-title">ドキュメント管理</h1>
+
+      {error && (
+        <p className="alert" role="alert">
+          {error}
+        </p>
+      )}
+
+      <UploadForm
+        onUpload={handleUpload}
+        isUploading={uploadMutation.isPending}
+      />
+
+      {documentsQuery.isPending && <p className="placeholder">読み込み中…</p>}
+
+      {documentsQuery.isError && (
+        <p className="placeholder">
+          {toErrorMessage(documentsQuery.error, "一覧を取得できませんでした")}{" "}
+          <button type="button" onClick={() => void documentsQuery.refetch()}>
+            再試行
+          </button>
+        </p>
+      )}
+
+      {documentsQuery.data &&
+        (documentsQuery.data.length === 0 ? (
+          <p className="placeholder">ドキュメントはまだありません</p>
+        ) : (
+          <div className="table-scroll">
+            <DocumentTable
+              documents={documentsQuery.data}
+              currentUserId={auth.user?.profile.sub}
+              onOpen={(id) => void handleOpen(id)}
+              onIngest={handleIngest}
+              openingId={openingId}
+              ingestingId={
+                ingestMutation.isPending
+                  ? (ingestMutation.variables ?? null)
+                  : null
+              }
+            />
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Home.tsx
+++ b/apps/frontend/src/pages/Home.tsx
@@ -1,22 +1,3 @@
-import { useAuth } from "react-oidc-context";
-import { redirectToCognitoLogout } from "../auth/userManager";
-
 export function Home() {
-  const auth = useAuth();
-
-  const handleSignOut = async () => {
-    // localStorageのトークンを破棄してからHosted UIのセッションを破棄する
-    await auth.removeUser();
-    redirectToCognitoLogout();
-  };
-
-  return (
-    <>
-      <header>
-        <span>{auth.user?.profile.name}</span>
-        <button onClick={() => void handleSignOut()}>サインアウト</button>
-      </header>
-      <h1>Event Driven RAG</h1>
-    </>
-  );
+  return <h1>Event Driven RAG</h1>;
 }


### PR DESCRIPTION
/documentsのドキュメント管理画面を実装し、一覧・アップロード・取込・原本閲覧を
SPAから行えるようにする。api-fnのドキュメントAPIは実装済みであり、本PRは
その利用側のみを追加する。

S3への直接PUTは、Authorizationヘッダーを付与するaxiosインスタンスを通すと
署名付きURLの署名と衝突するため、素のaxiosで送る。Content-Typeは署名に含まれる
ので、URL発行時とPUT時で同じ値を送る必要がある。File.typeはMarkdownで空になる
ブラウザがあるため、拡張子から決めている。

取込はSQS経由の非同期処理のため、processingの行がある間だけ3秒間隔で一覧を
ポーリングし、ingested/failedで停止する。取込開始ボタンは、api-fnが本人の
ドキュメントしか受け付けないため、自分の行かつuploaded/failedのときのみ表示する。

feat(frontend): add document API client and shared helpers

feat(frontend): add document management screen

feat(frontend): route /documents behind a shared layout

Closes #16 