### PR TITLE
Enhance linting rules and document code style guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,106 @@ Target architecture (from `docs/architecture.md`; most of it is not yet implemen
 - **CDK is planned as four stacks**: DataStack, AppStack, EdgeStack, CiStack (all but CiStack are implemented; see `cdk/README.md` for deploy prerequisites like the manual SSM SecureString setup and the `-c appDomain=` second pass). The SPA bucket lives in EdgeStack, not DataStack, because its OAC policy references the distribution.
 - **Logging**: Lambda Powertools (structured logging, metrics, tracing); propagate the request ID across services.
 
+## TypeScript Code Style
+
+### Readability
+
+- Optimize for the reader, not for line count.
+- Prefer explicit `if` statements and block bodies when compact expressions reduce readability.
+- Avoid nested ternary operators and nested arrow functions.
+- Name every branch when handling finite sets of cases such as string unions, enums, or state machines.
+- Prefer code that can be understood by reading top-to-bottom without mentally expanding expressions.
+- Widely-shared ecosystem idioms that clearly communicate intent are not considered clever shortcuts. Do not use this exception to justify complex expressions or compressed business logic.
+- Prefer early returns over deeply nested control flow.
+- Introduce well-named intermediate variables when an expression performs multiple logical steps.
+
+### Simplicity
+
+- Introduce intermediate variables only to clarify intent or separate logical steps.
+- Avoid unnecessary wrapper functions or abstractions.
+- Avoid adding abstractions before they solve a real problem.
+- Keep related code together. Split files only when responsibilities clearly diverge.
+
+### Comments
+
+Comments are the exception, not the default.
+
+Prefer expressive names, types, and structure over comments.
+
+Write comments only when the reason, constraint, or invariant cannot be inferred from the code.
+
+Good comments explain:
+
+- design constraints
+- cross-module contracts
+- platform or framework behavior that surprises experienced developers
+- intentional deviations from the obvious implementation
+
+Do not comment:
+
+- what the code already says
+- function summaries
+- parameter descriptions
+- control flow
+- language or library basics
+
+Python docstrings follow the same principles:
+
+- A module docstring carries the why: constraints, cross-module contracts, and intentional deviations from the obvious implementation.
+- A function docstring is a single line, and only when the name, types, and signature cannot fully express the contract.
+- Do not write `Args:` / `Returns:` sections that merely repeat parameter names and type annotations.
+- Write a `Raises:` section only when callers need to know about a specific exception as part of the function contract.
+
+Keep comments concise (normally 1–3 lines).
+
+If an explanation requires a paragraph, move it to CLAUDE.md (project rules) or docs/architecture.md / ADR (architectural rationale) and reference it instead.
+
+## Python Code Style
+
+Applies to `apps/backend/`.
+
+### Data shapes
+
+- Prefer named structures when values have semantic meaning.
+- Prefer `dataclass` or `NamedTuple` for internal models. Use `TypedDict` for dictionary-shaped external data such as JSON.
+- Avoid anonymous or loosely typed nested dictionaries when the schema is part of the contract. Define explicit types instead.
+- Fully parameterize container types. Avoid incomplete annotations such as `list` or `dict`.
+- Use `Any` only at boundaries where precise typing is not practical (for example, interacting with untyped third-party libraries).
+- Prefer named field access over positional indexing when the data has semantic fields.
+
+### State and loops
+
+- Prefer comprehensions and built-in transformations over manual accumulation when practical.
+- Avoid synchronizing multiple mutable variables that represent the same state.
+- Avoid maintaining duplicate mutable state. Prefer recomputing derived values unless caching is required for performance.
+- When an algorithm requires non-obvious state management, document the invariant or constraint that must be preserved.
+- Prefer introducing a new local variable instead of reassigning parameters.
+
+## Japanese Writing Quality
+
+When generating Japanese text (including comments, documentation, ADRs, issues, PR descriptions, and commit messages), prioritize natural Japanese over literal translation from English.
+
+### Writing Principles
+
+- Do not translate English expressions literally. Preserve the meaning while using natural Japanese.
+- Prefer wording commonly used in Japanese technical documentation.
+- Follow the terminology and writing style already established in this repository.
+- Avoid introducing unnatural or novel expressions when a standard Japanese equivalent exists.
+- Prioritize readability and clarity over preserving the original English sentence structure.
+
+### Self-Review Before Writing
+
+Review the text from the perspective of a native Japanese reader.
+
+Verify that:
+
+- The text does not read like a literal translation from English.
+- The wording is natural and idiomatic for Japanese readers.
+- Terminology is consistent throughout the document and with the rest of the repository.
+- The sentences are easy to read and understand without awkward phrasing.
+
+If there is a more natural way to express the same meaning in Japanese, prefer that wording over a literal translation.
+
 ## Notes
 
 - The architecture diagram is generated by `docs/diagrams/event_driven_rag.py` (requires `diagrams` + graphviz); regenerate `docs/diagrams/architecture.png` when the architecture changes.

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -56,4 +56,7 @@ src = ["."]
 [tool.ruff.lint]
 # 既定(E4/E7/E9/F)にI(isort)を追加し、import順をmake lintで強制する。
 # 選択を明示することでエディタ側の既定ルールセットとの食い違いも防ぐ
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["E4", "E7", "E9", "F", "I", "B", "UP", "RUF"]
+# コメントとdocstringは日本語で書く方針のため、全角記号やカタカナを
+# 半角英数の誤記と見なすRUF001-003は誤検知しか出さない
+ignore = ["RUF001", "RUF002", "RUF003"]

--- a/apps/backend/tests/rag/fakes.py
+++ b/apps/backend/tests/rag/fakes.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from app.rag.chains import RagChains
 from app.rag.state import GradeAnswer
@@ -65,9 +65,9 @@ class FakeRetriever(BaseRetriever):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    results: dict[str, list[Document]] = {}
-    default: list[Document] = []
-    queries: list[str] = []
+    results: dict[str, list[Document]] = Field(default_factory=dict)
+    default: list[Document] = Field(default_factory=list)
+    queries: list[str] = Field(default_factory=list)
 
     async def _aget_relevant_documents(self, query: str, *, run_manager=None):
         self.queries.append(query)

--- a/apps/backend/tests/test_ingest_handler.py
+++ b/apps/backend/tests/test_ingest_handler.py
@@ -8,9 +8,11 @@ from types import SimpleNamespace
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 
 from app.ingest.embeddings import EMBEDDING_DIMENSION
-from app.ingest.pipeline import IngestPipeline
+from app.ingest.extract import UnsupportedFileTypeError
+from app.ingest.pipeline import DocumentNotFoundError, IngestPipeline
 from app.ingest.vectors import VectorIndex
 from app.ingest_handler import handler
 from app.repositories.documents import DocumentRepository
@@ -211,7 +213,7 @@ def test_marks_failed_and_reraises_when_file_is_missing(
         status="processing",
     )
 
-    with pytest.raises(Exception):
+    with pytest.raises(ClientError):
         handler(build_event(), lambda_context)
 
     assert get_document(aws)["status"] == "failed"
@@ -228,7 +230,7 @@ def test_marks_failed_for_unsupported_file_type(aws, pipeline, lambda_context):
     )
     upload(aws, b"binary", key=f"documents/{USER_ID}/{DOCUMENT_ID}/sheet.xlsx")
 
-    with pytest.raises(Exception):
+    with pytest.raises(UnsupportedFileTypeError):
         handler(
             build_event(s3_key=f"documents/{USER_ID}/{DOCUMENT_ID}/sheet.xlsx"),
             lambda_context,
@@ -262,7 +264,7 @@ def test_marks_failed_when_embedding_api_fails(
 
 def test_unknown_document_raises_without_creating_item(aws, pipeline, lambda_context):
     """DynamoDBに存在しないドキュメントのメッセージでもfailed更新で新規作成しない。"""
-    with pytest.raises(Exception):
+    with pytest.raises(DocumentNotFoundError):
         handler(build_event(), lambda_context)
 
     response = aws.table.get_item(


### PR DESCRIPTION
コードレビューで適用してきた可読性・コメント・型付けの基準をCLAUDE.mdへ明文化し、
機械的に判定できるものはruffへ委ねる。規約を既存コードへ適用する作業は別PRで行い、
本PRは規約とlint設定の追加までとする。

ruffのselectにB・UP・RUFを追加した。RUF001〜003はコメントとdocstringを日本語で書く
方針と相性が悪く、全角記号やカタカナを半角英数の誤記として拾い続けるため、理由を
添えてignoreしている。

追加したルールが既存のテストコードを2箇所検出したので、あわせて修正した。
FakeRetrieverはクラス属性の既定値に空の辞書とリストを置いていた(RUF012)。pydanticの
モデルは既定値をインスタンスごとに複製するため実害はないが、素のクラスと同じ書き方を
残さずdefault_factoryへ変更した。ingest-fnのテストはpytest.raisesにExceptionを渡して
おり(B017)、取込と無関係な失敗でもテストが通るため、期待する例外型を指定するように
した。

chore(backend): tighten the ruff rule set

docs: add TypeScript and Python code style rules 

Closes #27 