### PR TITLE
Apply the code style rules to the existing code

### DIFF
--- a/apps/backend/app/ingest/pipeline.py
+++ b/apps/backend/app/ingest/pipeline.py
@@ -7,7 +7,7 @@ SSMからのAPIキー取得やクライアント生成のオーバーヘッド�
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any
+from typing import Any, Protocol
 
 import boto3
 
@@ -28,12 +28,17 @@ class DocumentNotFoundError(Exception):
     """SQSメッセージが指すドキュメントがDynamoDBに存在しない。"""
 
 
+class Embedder(Protocol):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]: ...
+
+
 @dataclass(frozen=True)
 class IngestPipeline:
     bucket_name: str
     repository: DocumentRepository
-    embedder: Any
+    embedder: Embedder
     vector_index: VectorIndex
+    # boto3のクライアントは動的に生成され、型を付けられない
     s3_client: Any
 
     def run(self, *, document_id: str, user_id: str, s3_key: str) -> int:
@@ -59,8 +64,7 @@ class IngestPipeline:
         )
         self._delete_stale_vectors(
             document_id=document_id,
-            # 初回取込ではchunkCountを持たないため0で代替する
-            # DynamoDBの数値はDecimalで返り、そのままではrange()に渡せない
+            # 初回取込ではchunkCountを持たない。Decimalのままではrange()へ渡せない
             previous_count=int(document.get("chunkCount", 0)),
             current_count=len(chunks),
         )

--- a/apps/backend/app/ingest_handler.py
+++ b/apps/backend/app/ingest_handler.py
@@ -8,18 +8,21 @@ SQSはbatchSize=1の為、そのメッセージだけが再試行され、maxRec
 """
 
 import json
+from typing import Any
 
-from app.ingest.pipeline import get_ingest_pipeline
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+from app.ingest.pipeline import IngestPipeline, get_ingest_pipeline
+from app.ingest_queue import IngestMessage
 from app.logger import logger
 from app.repositories.documents import DocumentStatusError
 
 FAILED_ALLOWED_FROM = ("processing", "failed", "ingested")
 
 
-# logger.inject_lambda_contextはLambda Powertools のデコレータで
-# Lambdaのコンテキスト情報(function_nameやLambdaランタイムが生成するaws_request_id等)を自動的にログに付与
+# Lambdaのコンテキスト情報(function_nameやaws_request_id等)を全ログへ付与する
 @logger.inject_lambda_context
-def handler(event, context):
+def handler(event: dict[str, Any], context: LambdaContext) -> None:
     """SQSイベントのRecordsを取り出し、1件ずつ取込処理へ渡す。
 
     1件でも失敗すると例外を送出するため、SQSは同じバッチ全体を再試行する。
@@ -30,8 +33,8 @@ def handler(event, context):
         _process_record(record)
 
 
-def _process_record(record: dict) -> None:
-    message = json.loads(record["body"])
+def _process_record(record: dict[str, Any]) -> None:
+    message: IngestMessage = json.loads(record["body"])
     document_id = message["documentId"]
     user_id = message["userId"]
     # api-fnが発番したRequest IDを引き継ぎ、取込完了までログを追跡する
@@ -53,7 +56,7 @@ def _process_record(record: dict) -> None:
         logger.remove_keys(["request_id", "document_id"])
 
 
-def _mark_failed(pipeline, *, user_id: str, document_id: str) -> None:
+def _mark_failed(pipeline: IngestPipeline, *, user_id: str, document_id: str) -> None:
     """ドキュメントのステータスをfailedへ更新する。
 
     取込失敗のraiseを上書きしない為、ステータス更新自体が失敗しても例外を外へ漏らさない。

--- a/apps/backend/app/ingest_queue.py
+++ b/apps/backend/app/ingest_queue.py
@@ -1,6 +1,16 @@
 import json
+from typing import TypedDict
 
 import boto3
+
+
+class IngestMessage(TypedDict):
+    """api-fnが送信し、ingest-fnが受け取るSQSメッセージ本文。"""
+
+    documentId: str
+    userId: str
+    s3Key: str
+    requestId: str
 
 
 class IngestQueue:
@@ -15,16 +25,14 @@ class IngestQueue:
         self, *, document_id: str, user_id: str, s3_key: str, request_id: str
     ) -> None:
         # request_idはRequest ID伝搬のために載せ、ingest-fnがログへ引き継ぐ
+        message: IngestMessage = {
+            "documentId": document_id,
+            "userId": user_id,
+            "s3Key": s3_key,
+            "requestId": request_id,
+        }
         self._client.send_message(
             QueueUrl=self._queue_url,
-            MessageBody=json.dumps(
-                {
-                    "documentId": document_id,
-                    "userId": user_id,
-                    "s3Key": s3_key,
-                    "requestId": request_id,
-                },
-                # 日本語などをエスケープせず、日本語のままJSON変換
-                ensure_ascii=False,
-            ),
+            # 日本語などをエスケープせず、日本語のままJSON変換
+            MessageBody=json.dumps(message, ensure_ascii=False),
         )

--- a/apps/backend/app/rag/state.py
+++ b/apps/backend/app/rag/state.py
@@ -40,17 +40,10 @@ class GradeAnswer(BaseModel):
 class GraphState(TypedDict):
     """Self-RAGワークフローがノード間で受け渡す状態。
 
-    Attributes:
-        question: ユーザーからの質問
-        queries: 試行ごとの検索クエリ
-        documents: 試行ごとの検索・リランク済みドキュメント
-        answer: 試行ごとの回答
-        grade: 試行ごとの評価
-        feedback: 試行ごとの評価理由
-        retry_count: ループ回数。初回は0で、再試行のたびに1増える
-        failure_analysis: 十分な回答が得られなかった場合の分析結果
-        user_id: ユーザーID(JWTのsub)
-        request_id: リクエストID
+    queries・documents・answer・grade・feedbackは試行ごとに1要素ずつ積み上がる。
+    retry_countは初回が0で、再試行のたびに1増える。
+    failure_analysisは再試行しても十分な回答が得られなかった場合のみ設定される。
+    user_idはJWTのsub。
     """
 
     question: str

--- a/apps/backend/app/rag/stream.py
+++ b/apps/backend/app/rag/stream.py
@@ -9,20 +9,28 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator
 from itertools import zip_longest
-from typing import Any
+from typing import Any, NamedTuple
 
 from langchain_core.documents import Document
 
 from app.logger import logger
 from app.rag.runtime import RagRuntime
-from app.repositories.chats import ChatRepository
+from app.repositories.chats import ChatRepository, RetrievedDocument
 
 # GraphStateで試行ごとに積み上がるキー。1ノードの更新差分は必ず1試行分の為、
 # SSEでは外側のリストを外して「そのノードが出した値」だけを送る
 ACCUMULATED_KEYS = frozenset({"queries", "documents", "answer", "grade", "feedback"})
 
 
-def to_document_payload(document: Document) -> dict:
+class Attempt(NamedTuple):
+    queries: list[str] | None
+    documents: list[Document] | None
+    answer: str | None
+    grade: str | None
+    feedback: str | None
+
+
+def to_document_payload(document: Document) -> RetrievedDocument:
     """Documentを、SSE・DynamoDB・既存GET APIで共通のshapeへ正規化する。"""
     metadata = document.metadata or {}
     return {
@@ -42,25 +50,26 @@ def _serialize_value(key: str, value: Any) -> Any:
     return value
 
 
-def _sse(event: str, data: dict) -> str:
+def _sse(event: str, data: dict[str, Any]) -> str:
     return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
-def _attempts(state: dict) -> list[tuple]:
+def _attempts(state: dict[str, Any]) -> list[Attempt]:
     """最終stateを試行ごとの行へ展開する。
 
     ノードによって積み上がる要素数が揃わない場合(失敗分析へ抜けた等)があるため、
     最長のリストに合わせてNoneで埋める。
     """
-    return list(
-        zip_longest(
+    return [
+        Attempt(*row)
+        for row in zip_longest(
             state.get("queries", []),
             state.get("documents", []),
             state.get("answer", []),
             state.get("grade", []),
             state.get("feedback", []),
         )
-    )
+    ]
 
 
 def persist(
@@ -69,7 +78,7 @@ def persist(
     user_id: str,
     chat_id: str,
     question: str,
-    state: dict,
+    state: dict[str, Any],
 ) -> None:
     """ヘッダーと試行ごとの全出力を書き込む。"""
     answers = state.get("answer") or []
@@ -84,19 +93,21 @@ def persist(
         retry_count=state.get("retry_count", 0),
     )
 
-    rows = _attempts(state)
-    for attempt_no, (queries, documents, answer, grade, feedback) in enumerate(rows):
+    attempts = _attempts(state)
+    for attempt_no, attempt in enumerate(attempts):
         # failure analysisは最終試行に対する分析のため、最後の行にだけ載せる
-        is_last = attempt_no == len(rows) - 1
+        is_last = attempt_no == len(attempts) - 1
         repository.put_attempt(
             user_id=user_id,
             chat_id=chat_id,
             attempt_no=attempt_no,
-            queries=list(queries or []),
-            documents=[to_document_payload(d) for d in documents or []],
-            answer=answer,
-            grade=grade,
-            feedback=feedback,
+            queries=list(attempt.queries or []),
+            documents=[
+                to_document_payload(document) for document in attempt.documents or []
+            ],
+            answer=attempt.answer,
+            grade=attempt.grade,
+            feedback=attempt.feedback,
             failure_analysis=state.get("failure_analysis") if is_last else None,
         )
 
@@ -113,7 +124,7 @@ async def generate_sse(
     """ノードごとのstate更新をSSEで配信し、完了後にdoneイベントを返す。"""
     logger.info("chat stream started", chat_id=chat_id, question=question[:50])
 
-    final_state: dict = {}
+    final_state: dict[str, Any] = {}
     try:
         async for mode, payload in runtime.graph.astream(
             {

--- a/apps/backend/app/rag/utils.py
+++ b/apps/backend/app/rag/utils.py
@@ -1,4 +1,12 @@
+from dataclasses import dataclass
+
 from langchain_core.documents import Document
+
+
+@dataclass
+class _FusedDocument:
+    document: Document
+    score: float = 0.0
 
 
 def reciprocal_rank_fusion(
@@ -6,27 +14,14 @@ def reciprocal_rank_fusion(
 ) -> list[Document]:
     """複数クエリの検索結果を相互順位融合(RRF)で1本に統合する。
 
-    Args:
-        retriever_outputs: クエリごとの検索結果
-        k: 順位の影響を緩めるRRFの定数
-        top_n: 返すドキュメント数
-
-    Returns:
-        スコア降順のドキュメント。同一ドキュメントはdoc.idで名寄せされる
+    同一ドキュメントはdoc.idで名寄せする。kは順位差の影響を緩める定数。
     """
-    # { doc_id: {score: スコア, document: Documentオブジェクト} }
-    doc_score_map: dict[str, dict] = {}
+    fused: dict[str, _FusedDocument] = {}
 
     for docs in retriever_outputs:
         for rank, doc in enumerate(docs):
-            if doc.id not in doc_score_map:
-                doc_score_map[doc.id] = {"score": 0.0, "document": doc}
-            doc_score_map[doc.id]["score"] += 1 / (rank + k)
+            entry = fused.setdefault(doc.id, _FusedDocument(document=doc))
+            entry.score += 1 / (rank + k)
 
-    sorted_items = sorted(
-        doc_score_map.items(),
-        key=lambda x: x[1]["score"],
-        reverse=True,  # 降順
-    )
-
-    return [item[1]["document"] for item in sorted_items[:top_n]]
+    ranked = sorted(fused.values(), key=lambda entry: entry.score, reverse=True)
+    return [entry.document for entry in ranked[:top_n]]

--- a/apps/backend/app/repositories/chats.py
+++ b/apps/backend/app/repositories/chats.py
@@ -1,11 +1,60 @@
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import TypedDict
 
 import boto3
 from boto3.dynamodb.conditions import Key
 
 # DynamoDBはfloatを受け付けないため、スコアはDecimalへ丸めて格納する
 SCORE_PRECISION = 6
+
+
+class RetrievedDocument(TypedDict):
+    """検索・リランク済みドキュメントの受け渡し形式。
+
+    SSE・DynamoDB・チャット詳細APIで同じshapeを使う(app/rag/stream.pyが生成する)。
+    """
+
+    documentId: str | None
+    filename: str | None
+    text: str
+    score: float | None
+
+
+class StoredRetrievedDocument(TypedDict):
+    """RetrievedDocumentをDynamoDBへ格納した形式。scoreのみDecimalになる。"""
+
+    documentId: str | None
+    filename: str | None
+    text: str
+    score: Decimal | None
+
+
+class ChatItem(TypedDict):
+    PK: str
+    SK: str
+    GSI1PK: str
+    GSI1SK: str
+    chatId: str
+    userId: str
+    question: str
+    finalAnswer: str | None
+    finalGrade: str | None
+    retryCount: int
+    createdAt: str
+
+
+class ChatAttemptItem(TypedDict):
+    PK: str
+    SK: str
+    chatId: str
+    attemptNo: int
+    queries: list[str]
+    documents: list[StoredRetrievedDocument]
+    answer: str | None
+    grade: str | None
+    feedback: str | None
+    failureAnalysis: str | None
 
 
 def _to_decimal(value: float | None) -> Decimal | None:
@@ -37,9 +86,9 @@ class ChatRepository:
         final_answer: str | None,
         final_grade: str | None,
         retry_count: int,
-    ) -> dict:
+    ) -> ChatItem:
         """チャットのヘッダを1件書き込む。一覧・詳細の入口になる。"""
-        item = {
+        item: ChatItem = {
             "PK": f"USER#{user_id}",
             "SK": f"CHAT#{chat_id}",
             "GSI1PK": "CHAT",
@@ -62,21 +111,21 @@ class ChatRepository:
         chat_id: str,
         attempt_no: int,
         queries: list[str],
-        documents: list[dict],
+        documents: list[RetrievedDocument],
         answer: str | None,
         grade: str | None,
         feedback: str | None,
         failure_analysis: str | None = None,
-    ) -> dict:
+    ) -> ChatAttemptItem:
         """1試行ぶんの全出力を書き込む。attemptNoは0始まり。"""
-        item = {
+        item: ChatAttemptItem = {
             "PK": f"USER#{user_id}",
             "SK": f"MSG#{chat_id}#{attempt_no}",
             "chatId": chat_id,
             "attemptNo": attempt_no,
             "queries": queries,
             "documents": [
-                {**doc, "score": _to_decimal(doc.get("score"))} for doc in documents
+                {**doc, "score": _to_decimal(doc["score"])} for doc in documents
             ],
             "answer": answer,
             "grade": grade,
@@ -86,7 +135,7 @@ class ChatRepository:
         self._table.put_item(Item=item)
         return item
 
-    def get(self, chat_id: str) -> dict | None:
+    def get(self, chat_id: str) -> ChatItem | None:
         """所有者を問わずchatIdで取得する。チャット詳細画面の入口。"""
         res = self._table.query(
             IndexName="GSI1",
@@ -95,7 +144,7 @@ class ChatRepository:
         items = res["Items"]
         return items[0] if items else None
 
-    def list_recent(self, limit: int) -> list[dict]:
+    def list_recent(self, limit: int) -> list[ChatItem]:
         res = self._table.query(
             IndexName="GSI1",
             KeyConditionExpression=Key("GSI1PK").eq("CHAT"),
@@ -104,7 +153,7 @@ class ChatRepository:
         )
         return res["Items"]
 
-    def list_by_user(self, user_id: str, limit: int) -> list[dict]:
+    def list_by_user(self, user_id: str, limit: int) -> list[ChatItem]:
         res = self._table.query(
             KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
             & Key("SK").begins_with("CHAT#"),
@@ -113,7 +162,7 @@ class ChatRepository:
         )
         return res["Items"]
 
-    def list_attempts(self, user_id: str, chat_id: str) -> list[dict]:
+    def list_attempts(self, user_id: str, chat_id: str) -> list[ChatAttemptItem]:
         res = self._table.query(
             KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
             & Key("SK").begins_with(f"MSG#{chat_id}#"),

--- a/apps/backend/app/repositories/documents.py
+++ b/apps/backend/app/repositories/documents.py
@@ -1,7 +1,31 @@
 from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Literal, NotRequired, TypedDict
 
 import boto3
 from boto3.dynamodb.conditions import Attr, Key
+
+DocumentStatus = Literal["uploading", "uploaded", "processing", "ingested", "failed"]
+
+
+class DocumentItem(TypedDict):
+    """DynamoDBに保存するDocumentsエンティティ。
+
+    chunkCountは取込完了時のみ付与される。DynamoDBは数値をDecimalで返す。
+    """
+
+    PK: str
+    SK: str
+    GSI1PK: str
+    GSI1SK: str
+    documentId: str
+    userId: str
+    filename: str
+    s3Key: str
+    status: DocumentStatus
+    createdAt: str
+    updatedAt: str
+    chunkCount: NotRequired[Decimal]
 
 
 class DocumentStatusError(Exception):
@@ -20,9 +44,9 @@ class DocumentRepository:
 
     def create(
         self, *, user_id: str, document_id: str, filename: str, s3_key: str
-    ) -> dict:
+    ) -> DocumentItem:
         now = datetime.now(UTC).isoformat()
-        item = {
+        item: DocumentItem = {
             "PK": f"USER#{user_id}",
             "SK": f"DOC#{document_id}",
             "GSI1PK": "DOC",
@@ -38,14 +62,14 @@ class DocumentRepository:
         self._table.put_item(Item=item)
         return item
 
-    def get_owned(self, user_id: str, document_id: str) -> dict | None:
+    def get_owned(self, user_id: str, document_id: str) -> DocumentItem | None:
         """本人のドキュメントを取得する。ステータス更新系の所有チェックに使う。"""
         res = self._table.get_item(
             Key={"PK": f"USER#{user_id}", "SK": f"DOC#{document_id}"}
         )
         return res.get("Item")
 
-    def get(self, document_id: str) -> dict | None:
+    def get(self, document_id: str) -> DocumentItem | None:
         """所有者を問わずdocumentIdで取得する。閲覧用presigned URL発行に使う。"""
         res = self._table.query(
             IndexName="GSI1",
@@ -55,7 +79,7 @@ class DocumentRepository:
         items = res["Items"]
         return items[0] if items else None
 
-    def list_recent(self, limit: int) -> list[dict]:
+    def list_recent(self, limit: int) -> list[DocumentItem]:
         res = self._table.query(
             IndexName="GSI1",
             KeyConditionExpression=Key("GSI1PK").eq("DOC"),
@@ -64,7 +88,7 @@ class DocumentRepository:
         )
         return res["Items"]
 
-    def list_by_user(self, user_id: str, limit: int) -> list[dict]:
+    def list_by_user(self, user_id: str, limit: int) -> list[DocumentItem]:
         res = self._table.query(
             KeyConditionExpression=Key("PK").eq(f"USER#{user_id}")
             & Key("SK").begins_with("DOC#"),
@@ -77,9 +101,9 @@ class DocumentRepository:
         self,
         user_id: str,
         document_id: str,
-        new_status: str,
+        new_status: DocumentStatus,
         *,
-        allowed_from: tuple[str, ...],
+        allowed_from: tuple[DocumentStatus, ...],
         chunk_count: int | None = None,
     ) -> None:
         """条件付き更新でステータスを遷移させる。
@@ -88,7 +112,7 @@ class DocumentRepository:
         chunk_countは取込完了時のみ指定し、再取込での余剰ベクトル削除に使う。
         """
         expression = "SET #status = :status, updatedAt = :now"
-        values: dict = {
+        values: dict[str, str | int] = {
             ":status": new_status,
             ":now": datetime.now(UTC).isoformat(),
         }

--- a/apps/backend/app/repositories/users.py
+++ b/apps/backend/app/repositories/users.py
@@ -1,6 +1,16 @@
 from datetime import UTC, datetime
+from typing import TypedDict
 
 import boto3
+
+
+class UserProfileItem(TypedDict):
+    PK: str
+    SK: str
+    displayName: str
+    email: str
+    createdAt: str
+    updatedAt: str
 
 
 class UserRepository:
@@ -13,7 +23,7 @@ class UserRepository:
     def __init__(self, table_name: str) -> None:
         self._table = boto3.resource("dynamodb").Table(table_name)
 
-    def get_profile(self, user_id: str) -> dict | None:
+    def get_profile(self, user_id: str) -> UserProfileItem | None:
         res = self._table.get_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"})
         return res.get("Item")
 

--- a/apps/backend/app/routers/chats.py
+++ b/apps/backend/app/routers/chats.py
@@ -40,7 +40,8 @@ def list_chats(
 ) -> list[ChatSummaryResponse]:
     """全ユーザーのチャット一覧を新しい順で返す。"""
     return [
-        ChatSummaryResponse.model_validate(i) for i in repository.list_recent(limit)
+        ChatSummaryResponse.model_validate(item)
+        for item in repository.list_recent(limit)
     ]
 
 

--- a/apps/backend/app/routers/documents.py
+++ b/apps/backend/app/routers/documents.py
@@ -46,7 +46,9 @@ def list_documents(
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
 ) -> list[DocumentResponse]:
     """全ユーザー横断のドキュメント一覧を新しい順で返す。"""
-    return [DocumentResponse.model_validate(i) for i in repository.list_recent(limit)]
+    return [
+        DocumentResponse.model_validate(item) for item in repository.list_recent(limit)
+    ]
 
 
 @router.post("/upload-url", status_code=status.HTTP_201_CREATED)

--- a/apps/backend/app/routers/users.py
+++ b/apps/backend/app/routers/users.py
@@ -63,8 +63,8 @@ def list_user_documents(
 ) -> list[DocumentResponse]:
     """指定ユーザーのドキュメント一覧を新しい順で返す。"""
     return [
-        DocumentResponse.model_validate(i)
-        for i in repository.list_by_user(user_id, limit)
+        DocumentResponse.model_validate(item)
+        for item in repository.list_by_user(user_id, limit)
     ]
 
 
@@ -77,6 +77,6 @@ def list_user_chats(
 ) -> list[ChatSummaryResponse]:
     """指定ユーザーのチャット一覧を新しい順で返す。"""
     return [
-        ChatSummaryResponse.model_validate(i)
-        for i in repository.list_by_user(user_id, limit)
+        ChatSummaryResponse.model_validate(item)
+        for item in repository.list_by_user(user_id, limit)
     ]

--- a/apps/frontend/src/pages/Documents.tsx
+++ b/apps/frontend/src/pages/Documents.tsx
@@ -85,6 +85,11 @@ export function Documents() {
     }
   };
 
+  // mutationのvariablesは実行中のdocumentIdを指す。完了後も直前の値が残る為isPendingで絞る
+  const ingestingId = ingestMutation.isPending
+    ? (ingestMutation.variables ?? null)
+    : null;
+
   const handleIngest = (documentId: string) => {
     setError(null);
     ingestMutation.mutate(documentId);
@@ -151,11 +156,7 @@ export function Documents() {
               onOpen={(id) => void handleOpen(id)}
               onIngest={handleIngest}
               openingId={openingId}
-              ingestingId={
-                ingestMutation.isPending
-                  ? (ingestMutation.variables ?? null)
-                  : null
-              }
+              ingestingId={ingestingId}
             />
           </div>
         ))}

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -12,8 +12,8 @@ import { DataStack } from "./data-stack";
 
 // SecureStringはCloudFormationで作成できない為、パラメータ本体は手動作成する
 // 手順はcdk/README.mdに記載
-// CDKは名前参照で読み取り権限のみ付与し、
-// CDK上ではパラメータ名のみを参照して読み取り権限を付与し、Lambdaには値ではなくパラメータ名を環境変数として渡す（ADR-0008）
+// CDKはパラメータ名のみを参照して読み取り権限を付与し、
+// Lambdaには値ではなくパラメータ名を環境変数として渡す(ADR-0008)
 export const OPENAI_API_KEY_PARAMETER_NAME = "/event-driven-rag/openai-api-key";
 export const COHERE_API_KEY_PARAMETER_NAME = "/event-driven-rag/cohere-api-key";
 

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -111,7 +111,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:aa8af4345dd2072921000bd79c7230d11fb6f910f5f8cc49657aaef8a0258984",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:b3c97b264e278c8020020761c5846ce3321e59b0f94f5be5c205d284e2cd0c70",
           },
         },
         "Environment": {
@@ -298,7 +298,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:482b32d67a421eadc32275d83244839741a0a81babf527ce447d37562ba527a4",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bdbc37d71cab34a05b0c5508ccf9c93c49cac674d8e41265cf4d95ef12922c45",
           },
         },
         "Environment": {
@@ -531,7 +531,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:21353185e5c874267d18e5e78c474bb6125a921e259efb8bd73d746b3ffa7999",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:6144fd29aecb1fd279927039245fb040e0b97deebe8ad726886143d103a564d2",
           },
         },
         "Environment": {

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,519 @@
+# コード規約の具体例
+
+CLAUDE.md の「TypeScript Code Style」「Python Code Style」「Comments」で定めた規約について、判断に迷いやすい箇所を実際のコードで示す。規約そのものは CLAUDE.md が正であり、この文書は解釈と適用例を補うものとする。
+
+引用元を示していないコード片は、説明のために書いた仮の例である。
+
+## 目次
+
+- [1. TypeScript](#1-typescript)
+  - [1.1 分岐に名前を付ける](#11-分岐に名前を付ける)
+  - [1.2 早期リターンで平坦にする](#12-早期リターンで平坦にする)
+  - [1.3 中間変数は業務ルールに名前を付けるために使う](#13-中間変数は業務ルールに名前を付けるために使う)
+  - [1.4 イディオムとして許容するもの](#14-イディオムとして許容するもの)
+  - [1.5 抽象化を先取りしない](#15-抽象化を先取りしない)
+  - [1.6 判断が割れる例](#16-判断が割れる例)
+- [2. コメントとdocstring](#2-コメントとdocstring)
+  - [2.1 残す価値のあるコメント](#21-残す価値のあるコメント)
+  - [2.2 消すべきコメント](#22-消すべきコメント)
+  - [2.3 docstring](#23-docstring)
+- [3. Python](#3-python)
+  - [3.1 匿名の入れ子dictを型にする](#31-匿名の入れ子dictを型にする)
+  - [3.2 外部データの形はTypedDictで宣言する](#32-外部データの形はtypeddictで宣言する)
+  - [3.3 Anyを使ってよい境界](#33-anyを使ってよい境界)
+  - [3.4 状態とループ](#34-状態とループ)
+- [4. 規約整備時に直した箇所](#4-規約整備時に直した箇所)
+
+## 1. TypeScript
+
+### 1.1 分岐に名前を付ける
+
+ステータスのような有限の文字列ユニオンを扱うときは、分岐そのものを値の対応表として書く。
+
+悪い例:
+
+```tsx
+export function StatusBadge({ status }: { status: DocumentStatus }) {
+  return (
+    <span className={`status-badge status-${status}`}>
+      {status === "uploading"
+        ? "アップロード中"
+        : status === "uploaded"
+          ? "未取込"
+          : status === "processing"
+            ? "取込中"
+            : status === "ingested"
+              ? "取込済"
+              : "失敗"}
+    </span>
+  );
+}
+```
+
+良い例（`apps/frontend/src/components/StatusBadge.tsx`）:
+
+```tsx
+const LABELS: Record<DocumentStatus, string> = {
+  uploading: "アップロード中",
+  uploaded: "未取込",
+  processing: "取込中",
+  ingested: "取込済",
+  failed: "失敗",
+};
+
+export function StatusBadge({ status }: { status: DocumentStatus }) {
+  return (
+    <span className={`status-badge status-${status}`}>
+      <span className="status-dot" aria-hidden="true" />
+      {LABELS[status] ?? status}
+    </span>
+  );
+}
+```
+
+`Record<DocumentStatus, string>` は全キーの定義を要求するため、`DocumentStatus` にステータスが増えたときに漏れがコンパイルエラーになる。三項演算子の連鎖では最後の `else` に吸い込まれて気付けない。
+
+### 1.2 早期リターンで平坦にする
+
+条件ごとに返す値が決まっている関数は、条件を並べて順に返す。
+
+悪い例:
+
+```ts
+export function toErrorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status;
+    if (status === 401 || status === 403) {
+      return "認証の有効期限が切れた可能性があります。ページを再読み込みしてください。";
+    } else if (status === 404) {
+      return "対象のドキュメントが見つかりません。一覧を再取得してください。";
+    } else {
+      if (!error.response) {
+        return `${fallback}（サーバーに接続できませんでした）`;
+      } else {
+        const detail = (error.response.data as { detail?: unknown } | undefined)
+          ?.detail;
+        return typeof detail === "string" ? `${fallback}（${detail}）` : fallback;
+      }
+    }
+  } else {
+    return fallback;
+  }
+}
+```
+
+良い例（`apps/frontend/src/lib/errors.ts`）:
+
+```ts
+export function toErrorMessage(error: unknown, fallback: string): string {
+  if (!axios.isAxiosError(error)) {
+    return fallback;
+  }
+  const status = error.response?.status;
+  if (status === 401 || status === 403) {
+    return "認証の有効期限が切れた可能性があります。ページを再読み込みしてください。";
+  }
+  if (status === 404) {
+    return "対象のドキュメントが見つかりません。一覧を再取得してください。";
+  }
+  if (status === 409) {
+    return "ドキュメントの状態が変わっています。一覧を再取得しました。";
+  }
+  if (!error.response) {
+    return `${fallback}（サーバーに接続できませんでした）`;
+  }
+  const detail = (error.response.data as { detail?: unknown } | undefined)
+    ?.detail;
+  return typeof detail === "string" ? `${fallback}（${detail}）` : fallback;
+}
+```
+
+条件が1段に揃うため、ケースの追加が1ブロックの追加で済む。最後の三項演算子は入れ子になっておらず「detailが文字列なら添える」という1段の判断なので残してよい。
+
+### 1.3 中間変数は業務ルールに名前を付けるために使う
+
+悪い例:
+
+```tsx
+{document.userId === currentUserId &&
+  ["uploaded", "failed"].includes(document.status) && (
+    <button type="button" onClick={() => onIngest(document.documentId)}>
+      取込開始
+    </button>
+  )}
+```
+
+良い例（`apps/frontend/src/components/DocumentTable.tsx`）:
+
+```tsx
+// バックエンドのステータス遷移(uploaded|failed → processing)に合わせる
+const INGESTABLE = ["uploaded", "failed"];
+
+const canIngest =
+  document.userId === currentUserId && INGESTABLE.includes(document.status);
+```
+
+「本人のドキュメントで、かつ取込可能な状態」という業務ルールに `canIngest` という名前が付く。JSXの中で条件を組み立てると、表示の都合と業務ルールが混ざって読み分けられなくなる。
+
+逆に、値を移し替えるだけの中間変数は入れない。次のような変数は `document.filename` をそのまま使えばよい。
+
+```ts
+const filename = document.filename; // 不要
+```
+
+ラッパー関数も同じ基準で判断する。`apps/frontend/src/pages/Documents.tsx` の `invalidateDocuments` は中身が1行だが3箇所から呼ばれ、「一覧のキャッシュを無効化する」という操作に名前を与えているので残す価値がある。呼び出しが1箇所しかない1行のラッパーは書かない。
+
+### 1.4 イディオムとして許容するもの
+
+```tsx
+onSuccess: () => void invalidateDocuments(),
+onOpen={(id) => void handleOpen(id)}
+```
+
+`void` は `no-misused-promises` に対して「戻り値のPromiseを意図的に捨てる」ことを示す定型表現で、エコシステムで広く共有されている。この例外は、意図が一目で伝わる定型表現にのみ適用する。`!!value` や `~list.indexOf(x)` のような、短さのために意味を圧縮した書き方はこの例外に含めない。
+
+### 1.5 抽象化を先取りしない
+
+悪い例:
+
+```ts
+function createResourceHooks<T>(queryKey: string[], fetcher: () => Promise<T[]>) {
+  return {
+    useList: () => useQuery({ queryKey, queryFn: fetcher }),
+    useInvalidate: () => {
+      const queryClient = useQueryClient();
+      return () => queryClient.invalidateQueries({ queryKey });
+    },
+  };
+}
+
+const documentHooks = createResourceHooks(["documents"], listDocuments);
+```
+
+良い例（`apps/frontend/src/pages/Documents.tsx`）:
+
+```ts
+const documentsQuery = useQuery({
+  queryKey: DOCUMENTS_QUERY_KEY,
+  queryFn: listDocuments,
+  // 取込中の行があればキャッシュを定期的に更新する。
+  refetchInterval: (query) =>
+    query.state.data?.some((document) => document.status === "processing")
+      ? POLL_INTERVAL_MS
+      : false,
+});
+```
+
+現時点で一覧を持つリソースはドキュメントだけであり、共通化しても呼び出し側は短くならない。むしろ `refetchInterval` のようなリソース固有の設定を汎用フックへ通す口が必要になり、抽象が壊れる。2つ目のリソースが現れて共通部分が確定してから括る。
+
+### 1.6 判断が割れる例
+
+`apps/frontend/src/pages/Documents.tsx` にあった次の記述は、入れ子の三項ではないため規約違反ではないが、JSXの属性内で条件と `??` が重なって読み取りに一拍かかる。
+
+```tsx
+ingestingId={
+  ingestMutation.isPending ? (ingestMutation.variables ?? null) : null
+}
+```
+
+変数へ抽出すると、`isPending` で絞る理由をコメントで補える位置ができる。
+
+```tsx
+// mutationのvariablesは実行中のdocumentIdを指す。完了後も直前の値が残る為isPendingで絞る
+const ingestingId = ingestMutation.isPending
+  ? (ingestMutation.variables ?? null)
+  : null;
+```
+
+この種の判断は「JSXを上から読んで各属性が何を渡しているか一読で分かるか」を基準にする。分からなければ props へ渡す前に名前を付ける。
+
+## 2. コメントとdocstring
+
+### 2.1 残す価値のあるコメント
+
+いずれもコードからは読み取れない理由・制約・他モジュールとの取り決めを書いている。
+
+```ts
+// apps/frontend/src/lib/fileTypes.ts
+// text/markdownはブラウザが表示せずダウンロードしてしまう為、原本閲覧のできるtext/plainで保存する。
+// バックエンドはContent-Typeではなく拡張子で形式を判定するので取込結果は変わらない
+".md": "text/plain; charset=utf-8",
+```
+
+```ts
+// apps/frontend/src/pages/Documents.tsx
+// await後のwindow.openはポップアップブロックの対象になる為、クリック直後に空タブを開く
+const tab = window.open("", "_blank");
+```
+
+```python
+# apps/backend/app/ingest/chunking.py
+"""抽出テキストを検索単位のチャンクへ分割する。
+
+langchain-text-splittersはlangchain-coreを引き込みworkerイメージを重くする為、自前実装する(ADR-0003)。
+"""
+```
+
+```python
+# apps/backend/app/ingest/pipeline.py
+"""再取込でチャンク数が減ったときに、余った古いベクトルを削除する。
+
+既存keyは上書きされるため、超過分だけを消せば良い
+ListVectorsにprefix絞り込みがない為、前回のチャンク数から削除対象を決める
+"""
+```
+
+判断基準は「このコメントを消したら、次に読む人が調べ直す羽目になるか」である。ADRで詳細を説明済みのものは、理由を1行に圧縮して参照先を書く。
+
+### 2.2 消すべきコメント
+
+コードがそのまま言っていることを繰り返すコメントは書かない。
+
+```python
+# apps/backend/app/rag/utils.py（修正前）
+sorted_items = sorted(
+    doc_score_map.items(),
+    key=lambda x: x[1]["score"],
+    reverse=True,  # 降順
+)
+```
+
+`reverse=True` は降順であり、コメントは情報を足していない。
+
+```ts
+// ドキュメント一覧を取得する
+export async function listDocuments(): Promise<DocumentSummary[]> {
+```
+
+関数名と戻り値の型が既に述べている。
+
+### 2.3 docstring
+
+悪い例（`apps/backend/app/rag/utils.py` の修正前）:
+
+```python
+def reciprocal_rank_fusion(
+    retriever_outputs: list[list[Document]], k: int = 60, top_n: int = 20
+) -> list[Document]:
+    """複数クエリの検索結果を相互順位融合(RRF)で1本に統合する。
+
+    Args:
+        retriever_outputs: クエリごとの検索結果
+        k: 順位の影響を緩めるRRFの定数
+        top_n: 返すドキュメント数
+
+    Returns:
+        スコア降順のドキュメント。同一ドキュメントはdoc.idで名寄せされる
+    """
+```
+
+`retriever_outputs` と `top_n` の説明は名前と型の言い換えでしかない。一方で「kが何の定数か」「同一ドキュメントをdoc.idで名寄せする」は署名から読み取れないため残す。
+
+良い例:
+
+```python
+def reciprocal_rank_fusion(
+    retriever_outputs: list[list[Document]], k: int = 60, top_n: int = 20
+) -> list[Document]:
+    """複数クエリの検索結果を相互順位融合(RRF)で1本に統合する。
+
+    同一ドキュメントはdoc.idで名寄せする。kは順位差の影響を緩める定数。
+    """
+```
+
+例外を契約として伝える場合は `Raises:` を書く。`DocumentRepository.update_status` の `DocumentStatusError` は呼び出し側が409へ変換する必要があるため、docstringで明示している。
+
+## 3. Python
+
+### 3.1 匿名の入れ子dictを型にする
+
+悪い例（`apps/backend/app/rag/utils.py` の修正前）:
+
+```python
+# { doc_id: {score: スコア, document: Documentオブジェクト} }
+doc_score_map: dict[str, dict] = {}
+
+for docs in retriever_outputs:
+    for rank, doc in enumerate(docs):
+        if doc.id not in doc_score_map:
+            doc_score_map[doc.id] = {"score": 0.0, "document": doc}
+        doc_score_map[doc.id]["score"] += 1 / (rank + k)
+
+sorted_items = sorted(doc_score_map.items(), key=lambda x: x[1]["score"], reverse=True)
+return [item[1]["document"] for item in sorted_items[:top_n]]
+```
+
+問題は3点ある。内側の `dict` が未パラメータ化で中身が型で表現されていないこと、その構造をコメントで補っていること、`item[1]["document"]` のように意味のあるフィールドを位置と文字列キーで取り出していることである。
+
+良い例:
+
+```python
+@dataclass
+class _FusedDocument:
+    document: Document
+    score: float = 0.0
+
+
+def reciprocal_rank_fusion(
+    retriever_outputs: list[list[Document]], k: int = 60, top_n: int = 20
+) -> list[Document]:
+    """複数クエリの検索結果を相互順位融合(RRF)で1本に統合する。
+
+    同一ドキュメントはdoc.idで名寄せする。kは順位差の影響を緩める定数。
+    """
+    fused: dict[str, _FusedDocument] = {}
+    for docs in retriever_outputs:
+        for rank, doc in enumerate(docs):
+            entry = fused.setdefault(doc.id, _FusedDocument(document=doc))
+            entry.score += 1 / (rank + k)
+
+    ranked = sorted(fused.values(), key=lambda entry: entry.score, reverse=True)
+    return [entry.document for entry in ranked[:top_n]]
+```
+
+構造を説明していたコメントが型定義に置き換わり、`entry.score` / `entry.document` で意味が読める。
+
+### 3.2 外部データの形はTypedDictで宣言する
+
+DynamoDBの項目のように、辞書の形が他モジュールとの契約になっているものは `TypedDict` で宣言する。
+
+悪い例（`apps/backend/app/repositories/documents.py` の修正前）:
+
+```python
+def get_owned(self, user_id: str, document_id: str) -> dict | None: ...
+def list_recent(self, limit: int) -> list[dict]: ...
+```
+
+呼び出し側は `document["s3Key"]` や `document.get("chunkCount", 0)` のようにキーを直接書くが、そのキーが存在するかどうかは型に現れない。
+
+良い例:
+
+```python
+class DocumentItem(TypedDict):
+    PK: str
+    SK: str
+    documentId: str
+    userId: str
+    filename: str
+    s3Key: str
+    status: str
+    createdAt: str
+    updatedAt: str
+
+
+class IngestedDocumentItem(DocumentItem):
+    # 取込完了後のみ付与される。再取込で余剰ベクトルを削除する際に参照する
+    chunkCount: NotRequired[Decimal]
+
+
+def get_owned(self, user_id: str, document_id: str) -> DocumentItem | None: ...
+def list_recent(self, limit: int) -> list[DocumentItem]: ...
+```
+
+`chunkCount` が任意項目であることや、DynamoDBの数値が `Decimal` で返ることが型に現れる。`pipeline.py` の次のコメントは、型が同じ内容を語るようになったため2行から1行へ減らせた。
+
+```python
+# 修正前
+# 初回取込ではchunkCountを持たないため0で代替する
+# DynamoDBの数値はDecimalで返り、そのままではrange()に渡せない
+previous_count=int(document.get("chunkCount", 0)),
+
+# 修正後
+# 初回取込ではchunkCountを持たない。Decimalのままではrange()へ渡せない
+previous_count=int(document.get("chunkCount", 0)),
+```
+
+### 3.3 Anyを使ってよい境界
+
+悪い例（`apps/backend/app/ingest/pipeline.py` の修正前）:
+
+```python
+@dataclass(frozen=True)
+class IngestPipeline:
+    bucket_name: str
+    repository: DocumentRepository
+    embedder: Any
+    vector_index: VectorIndex
+    s3_client: Any
+```
+
+`s3_client` は boto3 が動的にクライアントを生成し正確な型を付けられないため `Any` が妥当である。一方 `embedder` は自前の `CohereEmbedder` であり、テストで差し替えたいだけなら必要なメソッドを `Protocol` で宣言できる。
+
+良い例:
+
+```python
+class Embedder(Protocol):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]: ...
+
+
+@dataclass(frozen=True)
+class IngestPipeline:
+    bucket_name: str
+    repository: DocumentRepository
+    embedder: Embedder
+    vector_index: VectorIndex
+    # boto3のクライアントは動的に生成され、型を付けられない
+    s3_client: Any
+```
+
+「型が付けられないから `Any`」と「差し替えたいから `Any`」を区別する。前者は理由をコメントに残し、後者は `Protocol` で必要なメソッドだけを宣言する。
+
+### 3.4 状態とループ
+
+同じ状態を表す変数を複数持たない。
+
+```python
+# 悪い例
+kept: list[str] = []
+kept_count = 0
+for chunk in chunks:
+    if chunk:
+        kept.append(chunk)
+        kept_count += 1
+
+# 良い例
+kept = [chunk for chunk in chunks if chunk]
+kept_count = len(kept)
+```
+
+引数は再代入せず、新しいローカル変数を導入する。
+
+```python
+# 悪い例
+def split_text(text: str, *, chunk_size: int = CHUNK_SIZE) -> list[str]:
+    text = text.strip()
+    ...
+
+# 良い例
+def split_text(text: str, *, chunk_size: int = CHUNK_SIZE) -> list[str]:
+    normalized = text.strip()
+    ...
+```
+
+複雑な状態管理が避けられない場合は、保つべき不変条件を書く。`apps/backend/app/ingest/chunking.py` の `_merge` が該当する。
+
+```python
+chunks: list[str] = []
+current: list[str] = []
+# currentをseparatorで連結したときの長さ
+total = 0
+```
+
+`total` は `current` から計算できる派生値だが、ループのたびに再計算するとチャンク分割が O(n²) になるため保持している。この場合は「`total` が何と一致していなければならないか」を1行で書く。派生値のキャッシュは、このように性能上の理由があるときに限る。
+
+## 4. 規約整備時に直した箇所
+
+規約を後から整備したため、既存コードに未適用の箇所が残っていた。次の箇所は適用済みである。
+
+| 箇所 | 内容 |
+| --- | --- |
+| `app/rag/utils.py` | `dict[str, dict]` を `_FusedDocument` へ。`Args:` / `Returns:` の羅列と `reverse=True,  # 降順` を削除し、位置指定アクセスを名前付きアクセスへ |
+| `app/repositories/*.py` | 戻り値の `dict` / `list[dict]` を `DocumentItem` / `ChatItem` / `ChatAttemptItem` / `UserProfileItem` へ。ステータスは `DocumentStatus` のLiteral型にした |
+| `app/rag/stream.py` | `to_document_payload` の戻り値を `RetrievedDocument` へ。`_attempts` の `list[tuple]` を `Attempt` NamedTupleにし、試行の各要素を名前で参照できるようにした |
+| `app/ingest_queue.py` / `app/ingest_handler.py` | SQSメッセージ本文を `IngestMessage` として宣言。Powertoolsデコレータの説明コメントを1行へ |
+| `app/ingest/pipeline.py` | `embedder: Any` を `Embedder` Protocolへ。`s3_client: Any` は理由をコメントに残して維持 |
+| `app/rag/state.py` | `GraphState` の `Attributes:` ブロックを、署名から読み取れない内容だけへ圧縮 |
+| `app/routers/*.py` | `model_validate(i) for i in ...` の `i` を `item` へ |
+| `apps/frontend/src/pages/Documents.tsx` | JSX属性内で組み立てていた `ingestingId` を変数へ抽出 |
+
+RAGまわり（`app/rag/`）は既存実装からの移植であり、規約整備前の書き方が入り込みやすい。移植を続けるときは、移植元の書き方をそのまま持ち込まないよう合わせて調整する。


### PR DESCRIPTION
CLAUDE.mdの規約を既存コードへ適用する。挙動は変えず、型注釈とコメント、命名の
整理に絞っている。あわせて適用例をdocs/code-style.mdへまとめた。

モジュール境界を越える辞書はTypedDictで宣言し、その値を生成する側へ置いた。
検索済みドキュメントの構造はchat-fnが組み立ててDynamoDBへ渡るが、この型を
app/rag側に置くとapi-fnがapp/ragをimportすることになり、LangChainがapi-fnの
イメージへ入ってしまう(ADR-0003)。そのためrepositories/chats.pyに定義している。
DynamoDBはfloatを受け付けずscoreだけDecimalへ変わるため、渡す側と保存後で型を
分けた。

Anyは性質の異なるものが混ざっていたので扱いを分けた。s3_clientはboto3が
クライアントを動的に生成し型を付けられないため、理由をコメントに残して
そのままにしている。embedderはテストで差し替えるためのAnyだったので、必要な
メソッドだけをEmbedder Protocolとして宣言した。

CDKのスナップショットを更新している。backendのソースはLambdaイメージの
アセットハッシュに含まれるため、backendに変更を入れるとAppStackのテンプレート
に必ず差分が出る。

refactor(backend): declare the shapes that cross module boundaries

refactor(frontend): lift the ingesting document id out of the JSX attribute

docs(cdk): drop the leftover line in the SSM parameter comment

docs: add code style examples drawn from this codebase

Closes #28 