### PR TITLE
Implement the chat detail and user detail screens

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ChatDetail } from "./pages/ChatDetail";
 import { Documents } from "./pages/Documents";
 import { Home } from "./pages/Home";
 import { NotFound } from "./pages/NotFound";
+import { UserDetail } from "./pages/UserDetail";
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
       >
         <Route path="/" element={<Home />} />
         <Route path="/chat/:chatId" element={<ChatDetail />} />
+        <Route path="/user/:userId" element={<UserDetail />} />
         <Route path="/documents" element={<Documents />} />
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from "react-router-dom";
 import { RequireAuth } from "./auth/RequireAuth";
 import { Layout } from "./components/Layout";
 import { AuthCallback } from "./pages/AuthCallback";
+import { ChatDetail } from "./pages/ChatDetail";
 import { Documents } from "./pages/Documents";
 import { Home } from "./pages/Home";
 import { NotFound } from "./pages/NotFound";
@@ -19,6 +20,7 @@ function App() {
         }
       >
         <Route path="/" element={<Home />} />
+        <Route path="/chat/:chatId" element={<ChatDetail />} />
         <Route path="/documents" element={<Documents />} />
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/apps/frontend/src/api/chats.ts
+++ b/apps/frontend/src/api/chats.ts
@@ -57,6 +57,21 @@ export interface ChatCompletion {
   retryCount: number;
 }
 
+/** 保存済みの1試行。失敗分析のように生成されない項目はnullで届く。 */
+export interface ChatAttempt {
+  attemptNo: number;
+  queries: string[];
+  documents: RetrievedDocument[];
+  answer: string | null;
+  grade: ChatGrade | null;
+  feedback: string | null;
+  failureAnalysis: string | null;
+}
+
+export interface ChatDetail extends ChatSummary {
+  attempts: ChatAttempt[];
+}
+
 interface ErrorPayload {
   message: string;
   requestId: string;
@@ -68,6 +83,12 @@ export type ChatStreamEvent =
 
 export async function listChats(): Promise<ChatSummary[]> {
   const res = await api.get<ChatSummary[]>("/chats");
+  return res.data;
+}
+
+/** チャット1件を試行ごとの全出力付きで取得する。 */
+export async function getChat(chatId: string): Promise<ChatDetail> {
+  const res = await api.get<ChatDetail>(`/chats/${chatId}`);
   return res.data;
 }
 

--- a/apps/frontend/src/api/users.ts
+++ b/apps/frontend/src/api/users.ts
@@ -1,0 +1,29 @@
+import type { ChatSummary } from "./chats";
+import { api } from "./client";
+import type { DocumentSummary } from "./documents";
+
+/** サインイン時にCognitoから同期したプロフィール。マスタはCognito側にある。 */
+export interface UserProfile {
+  userId: string;
+  displayName: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchUser(userId: string): Promise<UserProfile> {
+  const res = await api.get<UserProfile>(`/users/${userId}`);
+  return res.data;
+}
+
+export async function listUserChats(userId: string): Promise<ChatSummary[]> {
+  const res = await api.get<ChatSummary[]>(`/users/${userId}/chats`);
+  return res.data;
+}
+
+export async function listUserDocuments(
+  userId: string,
+): Promise<DocumentSummary[]> {
+  const res = await api.get<DocumentSummary[]>(`/users/${userId}/documents`);
+  return res.data;
+}

--- a/apps/frontend/src/components/ChatHistory.css
+++ b/apps/frontend/src/components/ChatHistory.css
@@ -4,14 +4,23 @@
   padding: 0;
 }
 
+.chat-history-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-right: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
 .chat-history-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 8px 16px;
+  flex: 1;
+  min-width: 0;
   padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
   color: var(--text-h);
   text-decoration: none;
 
@@ -56,10 +65,17 @@
   color: var(--status-progress);
 }
 
-.chat-mine {
+.chat-owner {
+  flex: none;
   font-size: 13px;
-  padding: 3px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
   background: var(--accent-bg);
   color: var(--accent);
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/apps/frontend/src/components/ChatHistory.tsx
+++ b/apps/frontend/src/components/ChatHistory.tsx
@@ -6,6 +6,8 @@ import "./ChatHistory.css";
 interface ChatHistoryProps {
   chats: ChatSummary[];
   currentUserId: string | undefined;
+  /** ユーザーページのように投稿者が自明な一覧では省く */
+  showOwner?: boolean;
 }
 
 const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
@@ -13,12 +15,16 @@ const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
   timeStyle: "short",
 });
 
-export function ChatHistory({ chats, currentUserId }: ChatHistoryProps) {
+export function ChatHistory({
+  chats,
+  currentUserId,
+  showOwner,
+}: ChatHistoryProps) {
   return (
     <ul className="chat-history">
       {chats.map((chat) => (
-        <li key={chat.chatId}>
-          {/* 詳細画面(/chat/:chatId)はIssue #18で実装する */}
+        // アンカーは入れ子にできない為、行リンクと投稿者リンクをliへ並べる
+        <li className="chat-history-row" key={chat.chatId}>
           <Link className="chat-history-item" to={`/chat/${chat.chatId}`}>
             <span className="chat-question">{chat.question}</span>
             <span className="chat-meta">
@@ -26,14 +32,16 @@ export function ChatHistory({ chats, currentUserId }: ChatHistoryProps) {
               {chat.retryCount > 0 && (
                 <span className="chat-retry">再試行{chat.retryCount}回</span>
               )}
-              {chat.userId === currentUserId && (
-                <span className="chat-mine">自分</span>
-              )}
               <time dateTime={chat.createdAt}>
                 {dateFormatter.format(new Date(chat.createdAt))}
               </time>
             </span>
           </Link>
+          {showOwner && (
+            <Link className="chat-owner" to={`/user/${chat.userId}`}>
+              {chat.userId === currentUserId ? "自分" : "ユーザー"}
+            </Link>
+          )}
         </li>
       ))}
     </ul>

--- a/apps/frontend/src/components/ChatProgress.css
+++ b/apps/frontend/src/components/ChatProgress.css
@@ -91,11 +91,36 @@
   }
 }
 
+.doc-open {
+  font: inherit;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent);
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .doc-score {
   font-family: var(--mono);
   font-size: 13px;
   margin-left: 8px;
   opacity: 0.8;
+}
+
+.answer-body {
+  margin: 6px 0 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
+  font-size: 14px;
+  color: var(--text);
+  /* 回答は改行を含む為そのまま表示する */
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .feedback {

--- a/apps/frontend/src/components/ChatProgress.tsx
+++ b/apps/frontend/src/components/ChatProgress.tsx
@@ -1,3 +1,4 @@
+import type { RetrievedDocument } from "../api/chats";
 import type { Attempt } from "../lib/chatProgress";
 import { GradeBadge } from "./GradeBadge";
 import "./ChatProgress.css";
@@ -36,9 +37,18 @@ const scoreFormatter = new Intl.NumberFormat("ja-JP", {
 interface ChatProgressProps {
   attempts: Attempt[];
   isStreaming: boolean;
+  /** 渡すと検索ドキュメントが原本を開くボタンになる */
+  onOpenDocument?: (documentId: string) => void;
+  /** 記録の閲覧では文字数ではなく回答本文を出す */
+  showAnswerBody?: boolean;
 }
 
-export function ChatProgress({ attempts, isStreaming }: ChatProgressProps) {
+export function ChatProgress({
+  attempts,
+  isStreaming,
+  onOpenDocument,
+  showAnswerBody,
+}: ChatProgressProps) {
   return (
     <section
       className="chat-progress"
@@ -67,7 +77,10 @@ export function ChatProgress({ attempts, isStreaming }: ChatProgressProps) {
                   <div className="step-body">
                     <span className="step-label">{step.label}</span>
                     <span className="step-sub">{step.sub}</span>
-                    {renderDetail(attempt, step.key)}
+                    {renderDetail(attempt, step.key, {
+                      onOpenDocument,
+                      showAnswerBody,
+                    })}
                   </div>
                 </li>
               ))}
@@ -100,7 +113,12 @@ function stepStatus(
   return key === runningKey ? "running" : "pending";
 }
 
-function renderDetail(attempt: Attempt, key: StepKey) {
+type DetailOptions = Pick<
+  ChatProgressProps,
+  "onOpenDocument" | "showAnswerBody"
+>;
+
+function renderDetail(attempt: Attempt, key: StepKey, options: DetailOptions) {
   if (key === "queries" && attempt.queries) {
     return (
       <ul className="step-detail">
@@ -119,7 +137,7 @@ function renderDetail(attempt: Attempt, key: StepKey) {
       <ul className="step-detail">
         {attempt.documents.map((document, index) => (
           <li key={index}>
-            {document.filename ?? "（ファイル名なし）"}
+            {renderDocumentName(document, options.onOpenDocument)}
             {document.score !== null && (
               <span className="doc-score">
                 {scoreFormatter.format(document.score)}
@@ -132,6 +150,9 @@ function renderDetail(attempt: Attempt, key: StepKey) {
   }
 
   if (key === "answer" && attempt.answer !== undefined) {
+    if (options.showAnswerBody) {
+      return <p className="answer-body">{attempt.answer}</p>;
+    }
     return (
       <p className="step-detail">
         回答を生成しました（{attempt.answer.length}文字）
@@ -149,4 +170,25 @@ function renderDetail(attempt: Attempt, key: StepKey) {
   }
 
   return null;
+}
+
+function renderDocumentName(
+  document: RetrievedDocument,
+  onOpenDocument: ((documentId: string) => void) | undefined,
+) {
+  const name = document.filename ?? "（ファイル名なし）";
+  // documentIdはS3 Vectorsのメタデータ由来で、欠けた断片は原本を辿れない
+  if (!onOpenDocument || !document.documentId) {
+    return name;
+  }
+  const documentId = document.documentId;
+  return (
+    <button
+      type="button"
+      className="doc-open"
+      onClick={() => onOpenDocument(documentId)}
+    >
+      {name}
+    </button>
+  );
 }

--- a/apps/frontend/src/components/DocumentTable.css
+++ b/apps/frontend/src/components/DocumentTable.css
@@ -28,6 +28,15 @@
     word-break: break-all;
   }
 
+  .owner {
+    white-space: nowrap;
+
+    a {
+      font-size: 14px;
+      color: var(--accent);
+    }
+  }
+
   .updated-at {
     font-family: var(--mono);
     font-size: 14px;

--- a/apps/frontend/src/components/DocumentTable.tsx
+++ b/apps/frontend/src/components/DocumentTable.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import type { DocumentSummary } from "../api/documents";
 import { StatusBadge } from "./StatusBadge";
 import "./DocumentTable.css";
@@ -8,6 +9,8 @@ interface DocumentTableProps {
   currentUserId: string | undefined;
   onOpen: (documentId: string) => void;
   openingId: string | null;
+  /** ユーザーページのように投稿者が自明な一覧では省く */
+  showOwner?: boolean;
   /** 省くと取込開始ボタンを出さない */
   onIngest?: (documentId: string) => void;
   ingestingId?: string | null;
@@ -26,6 +29,7 @@ export function DocumentTable({
   currentUserId,
   onOpen,
   openingId,
+  showOwner,
   onIngest,
   ingestingId,
 }: DocumentTableProps) {
@@ -35,6 +39,7 @@ export function DocumentTable({
         <tr>
           <th scope="col">ファイル名</th>
           <th scope="col">状態</th>
+          {showOwner && <th scope="col">投稿者</th>}
           <th scope="col">更新日時</th>
           <th scope="col">操作</th>
         </tr>
@@ -51,6 +56,13 @@ export function DocumentTable({
               <td>
                 <StatusBadge status={document.status} />
               </td>
+              {showOwner && (
+                <td className="owner">
+                  <Link to={`/user/${document.userId}`}>
+                    {document.userId === currentUserId ? "自分" : "ユーザー"}
+                  </Link>
+                </td>
+              )}
               <td className="updated-at">
                 {dateFormatter.format(new Date(document.updatedAt))}
               </td>

--- a/apps/frontend/src/components/DocumentTable.tsx
+++ b/apps/frontend/src/components/DocumentTable.tsx
@@ -7,9 +7,10 @@ interface DocumentTableProps {
   /** サインイン中のユーザーのsub。取込は本人のドキュメントにしか実行できない */
   currentUserId: string | undefined;
   onOpen: (documentId: string) => void;
-  onIngest: (documentId: string) => void;
   openingId: string | null;
-  ingestingId: string | null;
+  /** 省くと取込開始ボタンを出さない */
+  onIngest?: (documentId: string) => void;
+  ingestingId?: string | null;
 }
 
 const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
@@ -24,8 +25,8 @@ export function DocumentTable({
   documents,
   currentUserId,
   onOpen,
-  onIngest,
   openingId,
+  onIngest,
   ingestingId,
 }: DocumentTableProps) {
   return (
@@ -41,6 +42,7 @@ export function DocumentTable({
       <tbody>
         {documents.map((document) => {
           const canIngest =
+            onIngest !== undefined &&
             document.userId === currentUserId &&
             INGESTABLE.includes(document.status);
           return (

--- a/apps/frontend/src/components/Layout.css
+++ b/apps/frontend/src/components/Layout.css
@@ -62,6 +62,15 @@
   margin-left: auto;
   font-size: 16px;
 
+  a {
+    color: var(--text-h);
+    text-decoration: none;
+
+    &:hover {
+      color: var(--accent);
+    }
+  }
+
   button {
     font: inherit;
     font-size: 15px;

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "react-oidc-context";
-import { NavLink, Outlet } from "react-router-dom";
+import { Link, NavLink, Outlet } from "react-router-dom";
 import { redirectToCognitoLogout } from "../auth/userManager";
 import "./Layout.css";
 
@@ -23,7 +23,11 @@ export function Layout() {
           <NavLink to="/documents">ドキュメント</NavLink>
         </nav>
         <div className="layout-user">
-          <span>{auth.user?.profile.name}</span>
+          {auth.user && (
+            <Link to={`/user/${auth.user.profile.sub}`}>
+              {auth.user.profile.name}
+            </Link>
+          )}
           <button type="button" onClick={() => void handleSignOut()}>
             サインアウト
           </button>

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -145,6 +145,48 @@ p {
   }
 }
 
+/* 最終回答はチャット画面とチャット詳細で共通の見た目にする */
+.final-answer {
+  padding: 16px;
+  margin-bottom: 24px;
+  border: 1px solid var(--accent-border);
+  border-radius: 8px;
+  background: var(--accent-bg);
+}
+
+.final-answer-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 10px;
+
+  h2 {
+    font-size: 20px;
+    margin: 0;
+  }
+
+  a {
+    margin-left: auto;
+    font-size: 14px;
+    color: var(--accent);
+  }
+}
+
+.final-answer-body {
+  font-size: 15px;
+  color: var(--text-h);
+  /* 回答は改行を含む為そのまま表示する */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.final-answer-note {
+  margin-top: 12px;
+  font-size: 14px;
+  color: var(--status-progress);
+}
+
 code,
 .counter {
   font-family: var(--mono);

--- a/apps/frontend/src/lib/chatProgress.ts
+++ b/apps/frontend/src/lib/chatProgress.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatAttempt,
   ChatGrade,
   ChatNodeUpdate,
   RetrievedDocument,
@@ -45,4 +46,16 @@ export function applyUpdate(
   }
 
   return [...attempts.slice(0, -1), current];
+}
+
+/** ChatProgressは未実施をundefinedで判定する為、RESTのnullを落とす。 */
+export function toAttempt(attempt: ChatAttempt): Attempt {
+  return {
+    queries: attempt.queries,
+    documents: attempt.documents,
+    answer: attempt.answer ?? undefined,
+    grade: attempt.grade ?? undefined,
+    feedback: attempt.feedback ?? undefined,
+    failureAnalysis: attempt.failureAnalysis ?? undefined,
+  };
 }

--- a/apps/frontend/src/lib/errors.ts
+++ b/apps/frontend/src/lib/errors.ts
@@ -8,6 +8,13 @@ export function toAuthErrorMessage(status: number | undefined): string | null {
   return null;
 }
 
+/** toErrorMessageの404は一覧の再取得を促す文言で、詳細画面には合わない。
+ * 画面ごとの案内へ差し替えられるよう判定だけ切り出す。
+ */
+export function isNotFound(error: unknown): boolean {
+  return axios.isAxiosError(error) && error.response?.status === 404;
+}
+
 /** FastAPIのHTTPExceptionは{"detail": "..."}を返す為、あれば補足として添える。 */
 export function toErrorMessage(error: unknown, fallback: string): string {
   if (!axios.isAxiosError(error)) {

--- a/apps/frontend/src/lib/useOpenDocument.ts
+++ b/apps/frontend/src/lib/useOpenDocument.ts
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { fetchDownloadUrl } from "../api/documents";
+import { toErrorMessage } from "./errors";
+
+/** 原本を別タブで開く。失敗の表示先はページごとに違う為、メッセージは呼び出し側へ渡す。 */
+export function useOpenDocument(onError: (message: string) => void) {
+  const [openingId, setOpeningId] = useState<string | null>(null);
+
+  const openDocument = async (documentId: string) => {
+    // await後のwindow.openはポップアップブロックの対象になる為、クリック直後に空タブを開く
+    const tab = window.open("", "_blank");
+    // 原本のContent-Type次第ではタブ内でスクリプトが動く為、開いた側への参照を切る
+    if (tab) tab.opener = null;
+    setOpeningId(documentId);
+    try {
+      const { downloadUrl } = await fetchDownloadUrl(documentId);
+      if (tab) {
+        tab.location.href = downloadUrl;
+      } else {
+        onError(
+          "別タブを開けませんでした。ブラウザのポップアップ設定を確認してください",
+        );
+      }
+    } catch (e) {
+      tab?.close();
+      onError(toErrorMessage(e, "原本の取得に失敗しました"));
+    } finally {
+      setOpeningId(null);
+    }
+  };
+
+  return { openDocument, openingId };
+}

--- a/apps/frontend/src/pages/ChatDetail.css
+++ b/apps/frontend/src/pages/ChatDetail.css
@@ -1,0 +1,47 @@
+.chat-question-block {
+  padding: 16px;
+  margin-bottom: 24px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.chat-question-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 10px;
+
+  h2 {
+    font-size: 20px;
+    margin: 0;
+  }
+
+  a {
+    margin-left: auto;
+    font-size: 14px;
+    color: var(--accent);
+  }
+}
+
+.chat-question-body {
+  font-size: 15px;
+  color: var(--text-h);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-question-time {
+  display: block;
+  margin-top: 10px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--text);
+}
+
+.attempts-title {
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--border);
+  font-size: 20px;
+}

--- a/apps/frontend/src/pages/ChatDetail.tsx
+++ b/apps/frontend/src/pages/ChatDetail.tsx
@@ -1,0 +1,103 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { getChat } from "../api/chats";
+import { ChatProgress } from "../components/ChatProgress";
+import { GradeBadge } from "../components/GradeBadge";
+import { toAttempt } from "../lib/chatProgress";
+import { isNotFound, toErrorMessage } from "../lib/errors";
+import { useOpenDocument } from "../lib/useOpenDocument";
+import "./ChatDetail.css";
+
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  dateStyle: "short",
+  timeStyle: "short",
+});
+
+export function ChatDetail() {
+  const params = useParams();
+  // ルート定義上chatIdは必ず入る
+  const chatId = params.chatId!;
+  const [error, setError] = useState<string | null>(null);
+  const { openDocument, openingId } = useOpenDocument(setError);
+
+  const chatQuery = useQuery({
+    queryKey: ["chat", chatId],
+    queryFn: () => getChat(chatId),
+  });
+
+  const handleOpen = (documentId: string) => {
+    setError(null);
+    void openDocument(documentId);
+  };
+
+  const chat = chatQuery.data;
+
+  return (
+    <div className="chat-detail">
+      <h1 className="page-title">チャット詳細</h1>
+
+      {error && (
+        <p className="alert" role="alert">
+          {error}
+        </p>
+      )}
+
+      {chatQuery.isPending && <p className="placeholder">読み込み中…</p>}
+
+      {chatQuery.isError &&
+        (isNotFound(chatQuery.error) ? (
+          <p className="placeholder">
+            チャットが見つかりません <Link to="/">チャット一覧へ戻る</Link>
+          </p>
+        ) : (
+          <p className="placeholder">
+            {toErrorMessage(chatQuery.error, "チャットを取得できませんでした")}{" "}
+            <button type="button" onClick={() => void chatQuery.refetch()}>
+              再試行
+            </button>
+          </p>
+        ))}
+
+      {chat && (
+        <>
+          <section className="chat-question-block">
+            <div className="chat-question-head">
+              <h2>質問</h2>
+              <Link to={`/user/${chat.userId}`}>質問者のページ</Link>
+            </div>
+            <p className="chat-question-body">{chat.question}</p>
+            <time className="chat-question-time" dateTime={chat.createdAt}>
+              {dateFormatter.format(new Date(chat.createdAt))}
+            </time>
+          </section>
+
+          {chat.finalAnswer !== null && (
+            <section className="final-answer">
+              <div className="final-answer-head">
+                <h2>回答</h2>
+                {chat.finalGrade && <GradeBadge grade={chat.finalGrade} />}
+              </div>
+              <p className="final-answer-body">{chat.finalAnswer}</p>
+              {/* 評価がusefulに達しない場合、バックエンドは必ず1回再試行してから終える */}
+              {chat.finalGrade && chat.finalGrade !== "useful" && (
+                <p className="final-answer-note">
+                  再試行しても自己評価が「有用」に達しませんでした。取り込み済みのドキュメントに根拠が無い可能性があります。
+                </p>
+              )}
+            </section>
+          )}
+
+          <h2 className="attempts-title">試行の記録</h2>
+          <ChatProgress
+            attempts={chat.attempts.map(toAttempt)}
+            isStreaming={false}
+            showAnswerBody
+            onOpenDocument={handleOpen}
+          />
+          {openingId && <p className="placeholder">原本を開いています…</p>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Documents.tsx
+++ b/apps/frontend/src/pages/Documents.tsx
@@ -135,8 +135,9 @@ export function Documents() {
               documents={documentsQuery.data}
               currentUserId={auth.user?.profile.sub}
               onOpen={handleOpen}
-              onIngest={handleIngest}
               openingId={openingId}
+              showOwner
+              onIngest={handleIngest}
               ingestingId={ingestingId}
             />
           </div>

--- a/apps/frontend/src/pages/Documents.tsx
+++ b/apps/frontend/src/pages/Documents.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "react-oidc-context";
 import {
   completeUpload,
   createUploadUrl,
-  fetchDownloadUrl,
   listDocuments,
   putToS3,
   startIngest,
@@ -13,6 +12,7 @@ import { DocumentTable } from "../components/DocumentTable";
 import { UploadForm } from "../components/UploadForm";
 import { toErrorMessage } from "../lib/errors";
 import { ACCEPTED_EXTENSIONS, contentTypeFor } from "../lib/fileTypes";
+import { useOpenDocument } from "../lib/useOpenDocument";
 import "./Documents.css";
 
 const DOCUMENTS_QUERY_KEY = ["documents"];
@@ -23,7 +23,7 @@ export function Documents() {
   const auth = useAuth();
   const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
-  const [openingId, setOpeningId] = useState<string | null>(null);
+  const { openDocument, openingId } = useOpenDocument(setError);
 
   const invalidateDocuments = () =>
     queryClient.invalidateQueries({ queryKey: DOCUMENTS_QUERY_KEY });
@@ -95,28 +95,9 @@ export function Documents() {
     ingestMutation.mutate(documentId);
   };
 
-  const handleOpen = async (documentId: string) => {
+  const handleOpen = (documentId: string) => {
     setError(null);
-    // await後のwindow.openはポップアップブロックの対象になる為、クリック直後に空タブを開く
-    const tab = window.open("", "_blank");
-    // 原本のContent-Type次第ではタブ内でスクリプトが動く為、開いた側への参照を切る
-    if (tab) tab.opener = null;
-    setOpeningId(documentId);
-    try {
-      const { downloadUrl } = await fetchDownloadUrl(documentId);
-      if (tab) {
-        tab.location.href = downloadUrl;
-      } else {
-        setError(
-          "別タブを開けませんでした。ブラウザのポップアップ設定を確認してください",
-        );
-      }
-    } catch (e) {
-      tab?.close();
-      setError(toErrorMessage(e, "原本の取得に失敗しました"));
-    } finally {
-      setOpeningId(null);
-    }
+    void openDocument(documentId);
   };
 
   return (
@@ -153,7 +134,7 @@ export function Documents() {
             <DocumentTable
               documents={documentsQuery.data}
               currentUserId={auth.user?.profile.sub}
-              onOpen={(id) => void handleOpen(id)}
+              onOpen={handleOpen}
               onIngest={handleIngest}
               openingId={openingId}
               ingestingId={ingestingId}

--- a/apps/frontend/src/pages/Home.css
+++ b/apps/frontend/src/pages/Home.css
@@ -1,3 +1,4 @@
+/* 最終回答(.final-answer)はチャット詳細と共有する為、index.cssにある */
 .home {
   .history-title {
     margin: 32px 0 4px;
@@ -5,45 +6,4 @@
     border-bottom: 2px solid var(--border);
     font-size: 20px;
   }
-}
-
-.final-answer {
-  padding: 16px;
-  margin-bottom: 24px;
-  border: 1px solid var(--accent-border);
-  border-radius: 8px;
-  background: var(--accent-bg);
-}
-
-.final-answer-head {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-bottom: 10px;
-
-  h2 {
-    font-size: 20px;
-    margin: 0;
-  }
-
-  a {
-    margin-left: auto;
-    font-size: 14px;
-    color: var(--accent);
-  }
-}
-
-.final-answer-body {
-  font-size: 15px;
-  color: var(--text-h);
-  /* 回答は改行を含む為そのまま表示する */
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.final-answer-note {
-  margin-top: 12px;
-  font-size: 14px;
-  color: var(--status-progress);
 }

--- a/apps/frontend/src/pages/Home.tsx
+++ b/apps/frontend/src/pages/Home.tsx
@@ -105,7 +105,6 @@ export function Home() {
             {completion.finalGrade && (
               <GradeBadge grade={completion.finalGrade} />
             )}
-            {/* 詳細画面(/chat/:chatId)はIssue #18で実装する */}
             <Link to={`/chat/${completion.chatId}`}>詳細を見る</Link>
           </div>
           <p className="final-answer-body">{finalAnswer}</p>

--- a/apps/frontend/src/pages/Home.tsx
+++ b/apps/frontend/src/pages/Home.tsx
@@ -137,6 +137,7 @@ export function Home() {
           <ChatHistory
             chats={chatsQuery.data}
             currentUserId={auth.user?.profile.sub}
+            showOwner
           />
         ))}
     </div>

--- a/apps/frontend/src/pages/NotFound.tsx
+++ b/apps/frontend/src/pages/NotFound.tsx
@@ -1,6 +1,5 @@
 import { Link } from "react-router-dom";
 
-/** /chat/:chatIdはIssue #18で実装する為、それまでは履歴から辿るとこの画面になる。 */
 export function NotFound() {
   return (
     <div>

--- a/apps/frontend/src/pages/UserDetail.css
+++ b/apps/frontend/src/pages/UserDetail.css
@@ -1,0 +1,47 @@
+.user-detail {
+  /* 画面が狭いときはテーブルだけを横スクロールさせ、ページ全体は横に伸ばさない */
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .section-title {
+    margin: 32px 0 4px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid var(--border);
+    font-size: 20px;
+  }
+}
+
+.user-profile {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+
+  h2 {
+    margin: 0 0 12px;
+    font-size: 20px;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 6px 16px;
+    margin: 0;
+    font-size: 14px;
+  }
+
+  dt {
+    color: var(--text);
+  }
+
+  dd {
+    margin: 0;
+    color: var(--text-h);
+    word-break: break-all;
+  }
+
+  time {
+    font-family: var(--mono);
+    font-size: 13px;
+  }
+}

--- a/apps/frontend/src/pages/UserDetail.tsx
+++ b/apps/frontend/src/pages/UserDetail.tsx
@@ -1,0 +1,135 @@
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useAuth } from "react-oidc-context";
+import { useParams } from "react-router-dom";
+import { fetchUser, listUserChats, listUserDocuments } from "../api/users";
+import { ChatHistory } from "../components/ChatHistory";
+import { DocumentTable } from "../components/DocumentTable";
+import { isNotFound, toErrorMessage } from "../lib/errors";
+import { useOpenDocument } from "../lib/useOpenDocument";
+import "./UserDetail.css";
+
+const dateFormatter = new Intl.DateTimeFormat("ja-JP", {
+  dateStyle: "short",
+  timeStyle: "short",
+});
+
+export function UserDetail() {
+  const params = useParams();
+  // ルート定義上userIdは必ず入る
+  const userId = params.userId!;
+  const auth = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const { openDocument, openingId } = useOpenDocument(setError);
+
+  const userQuery = useQuery({
+    queryKey: ["user", userId],
+    queryFn: () => fetchUser(userId),
+  });
+  const chatsQuery = useQuery({
+    queryKey: ["user", userId, "chats"],
+    queryFn: () => listUserChats(userId),
+  });
+  const documentsQuery = useQuery({
+    queryKey: ["user", userId, "documents"],
+    queryFn: () => listUserDocuments(userId),
+  });
+
+  const handleOpen = (documentId: string) => {
+    setError(null);
+    void openDocument(documentId);
+  };
+
+  return (
+    <div className="user-detail">
+      <h1 className="page-title">ユーザー</h1>
+
+      {error && (
+        <p className="alert" role="alert">
+          {error}
+        </p>
+      )}
+
+      {userQuery.isPending && <p className="placeholder">読み込み中…</p>}
+
+      {userQuery.isError &&
+        (isNotFound(userQuery.error) ? (
+          <p className="placeholder">ユーザーが見つかりません</p>
+        ) : (
+          <p className="placeholder">
+            {toErrorMessage(userQuery.error, "ユーザーを取得できませんでした")}{" "}
+            <button type="button" onClick={() => void userQuery.refetch()}>
+              再試行
+            </button>
+          </p>
+        ))}
+
+      {userQuery.data && (
+        <section className="user-profile">
+          <h2>{userQuery.data.displayName}</h2>
+          <dl>
+            <dt>メールアドレス</dt>
+            <dd>{userQuery.data.email}</dd>
+            <dt>登録日時</dt>
+            <dd>
+              <time dateTime={userQuery.data.createdAt}>
+                {dateFormatter.format(new Date(userQuery.data.createdAt))}
+              </time>
+            </dd>
+          </dl>
+        </section>
+      )}
+
+      <h2 className="section-title">チャット履歴</h2>
+
+      {chatsQuery.isPending && <p className="placeholder">読み込み中…</p>}
+
+      {chatsQuery.isError && (
+        <p className="placeholder">
+          {toErrorMessage(chatsQuery.error, "履歴を取得できませんでした")}{" "}
+          <button type="button" onClick={() => void chatsQuery.refetch()}>
+            再試行
+          </button>
+        </p>
+      )}
+
+      {chatsQuery.data &&
+        (chatsQuery.data.length === 0 ? (
+          <p className="placeholder">チャットはまだありません</p>
+        ) : (
+          <ChatHistory
+            chats={chatsQuery.data}
+            currentUserId={auth.user?.profile.sub}
+          />
+        ))}
+
+      <h2 className="section-title">アップロード履歴</h2>
+
+      {documentsQuery.isPending && <p className="placeholder">読み込み中…</p>}
+
+      {documentsQuery.isError && (
+        <p className="placeholder">
+          {toErrorMessage(documentsQuery.error, "一覧を取得できませんでした")}{" "}
+          <button type="button" onClick={() => void documentsQuery.refetch()}>
+            再試行
+          </button>
+        </p>
+      )}
+
+      {documentsQuery.data &&
+        (documentsQuery.data.length === 0 ? (
+          <p className="placeholder">ドキュメントはまだありません</p>
+        ) : (
+          <div className="table-scroll">
+            {/* 取込は/documentsに集約している為、ここは閲覧だけ */}
+            <DocumentTable
+              documents={documentsQuery.data}
+              currentUserId={auth.user?.profile.sub}
+              onOpen={handleOpen}
+              openingId={openingId}
+            />
+          </div>
+        ))}
+    </div>
+  );
+}


### PR DESCRIPTION
チャット詳細(`/chat/{chat_id}`)とユーザーページ(`/user/{user_id}`)を実装する。どちらも
ルーティング表には定義済みだが未実装で、チャット履歴の行と回答の「詳細を見る」は存在
しないルートを指しており、NotFoundへ落ちていた。バックエンドのAPIは実装済みであり、
本PRはその利用側のみを扱う。

試行ごとの表示は、専用コンポーネントを新設せずChatProgressへonOpenDocumentと
showAnswerBodyを足して再利用した。並べる項目は生成中と同じで、違いは検索ドキュメントに
リンクを付けるかと、回答を文字数で示すか本文で示すかだけである。ただしRESTとSSEでは
欠損の表し方が違い、RESTは未生成の項目をnullで返す。ChatProgressはundefinedで未実施を
判定するため、そのまま渡すと全ステップが完了扱いになる。toAttemptでnullを落としてから
渡している。

原本を開く処理はuseOpenDocumentへ切り出した。await後のwindow.openはポップアップブロック
の対象になるため、クリック直後に空タブを開いてから署名付きURLを取りに行く必要がある。
この手順はドキュメント管理・チャット詳細・ユーザーページの3箇所で必要になり、書き写すと
壊しやすい。

404はisNotFoundで判定し、画面ごとの文言を出すようにした。toErrorMessageの404は一覧の
再取得を促すドキュメント向けの文言を返すため、詳細画面でそのまま使うと誤った案内になる。

ユーザー情報・チャット履歴・アップロード履歴は、Issueでは`GET /api/users/{user_id}`
1本と書いているが、バックエンドは3つのエンドポイントに分かれている。実装は現行のAPIへ
合わせて3クエリで取得しており、バックエンドは変更していない。

一覧からユーザーページへの導線は、チャット履歴では行全体が`<Link>`で内側に置けないため、
liをflexコンテナにして行リンクと投稿者リンクを横に並べている。一覧APIは表示名を返さず
userIdしか持たないため、ラベルは「自分」と「ユーザー」に留め、表示名は遷移先で見せる。
ユーザーページ自身では投稿者が自明なのでshowOwnerを渡さず、列を出さない。あわせて、
Issueには無いがヘッダーのユーザー名を自分のページへのリンクにした。

refactor(frontend): extract the document open flow into a hook

feat(frontend): add the chat detail screen

feat(frontend): add the user detail screen

feat(frontend): link the chat and document lists to the user page

Closes #18 