### PR TITLE
Build the CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
         working-directory: apps/backend
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v9
+      # setup-uvはv7までしか移動メジャータグを打っていない為、リリースタグで固定する
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           # uvのバージョン解決とキャッシュキーをbackendのuv.lockに合わせる
           working-directory: apps/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# 検証のみでAWSへは接続しない
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: apps/frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      # VITE_COGNITO_*はビルド時に埋め込まれるが、型検査とバンドルは値なしでも通る。
+      # 実際の値の注入はdeploy-frontend.ymlが行う
+      - run: npm run build
+
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/backend
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v9
+        with:
+          # uvのバージョン解決とキャッシュキーをbackendのuv.lockに合わせる
+          working-directory: apps/backend
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --frozen
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      # テストはconftest.pyのfixtureとmotoで完結する為、AWS認証情報は不要
+      - run: uv run pytest
+
+  cdk:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cdk
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: cdk/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      # コンテナアセットのビルドはcdk-assetsがデプロイ時に行う為、Dockerは要らない
+      - run: npm test

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,100 @@
+name: Deploy backend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/backend/**
+      - .github/workflows/deploy-backend.yml
+  workflow_dispatch:
+
+permissions:
+  # OIDCトークンの発行に必要。長期アクセスキーは持たせない
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-backend
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  # ECRのURIとLambda名はCDKの自動生成名の為、AppStackの出力から引く
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      ecr_uri: ${{ steps.outputs.outputs.ecr_uri }}
+      functions: ${{ steps.outputs.outputs.functions }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ secrets.AWS_ACCOUNT_ID }}
+
+      - id: outputs
+        run: |
+          outputs=$(aws cloudformation describe-stacks \
+            --stack-name AppStack \
+            --query 'Stacks[0].Outputs' --output json)
+          read_output() {
+            echo "$outputs" | jq -er --arg key "$1" \
+              '.[] | select(.OutputKey == $key) | .OutputValue'
+          }
+          echo "ecr_uri=$(read_output EcrRepositoryUri)" >> "$GITHUB_OUTPUT"
+          # Dockerfileのターゲット名をキーにして、matrixから引ける形で渡す
+          functions=$(jq -cn \
+            --arg web "$(read_output ApiFunctionName)" \
+            --arg chat "$(read_output ChatFunctionName)" \
+            --arg worker "$(read_output IngestFunctionName)" \
+            '{web: $web, chat: $chat, worker: $worker}')
+          echo "functions=$functions" >> "$GITHUB_OUTPUT"
+
+  deploy:
+    needs: resolve
+    runs-on: ubuntu-latest
+    strategy:
+      # 1つのターゲットが失敗しても残りは反映させる
+      fail-fast: false
+      matrix:
+        target: [web, chat, worker]
+    env:
+      IMAGE_URI: ${{ needs.resolve.outputs.ecr_uri }}:${{ matrix.target }}-${{ github.sha }}
+      FUNCTION_NAME: ${{ fromJSON(needs.resolve.outputs.functions)[matrix.target] }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ secrets.AWS_ACCOUNT_ID }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      # DockerfileがRUN --mount=type=cacheを使う為buildxが要る
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: apps/backend
+          target: ${{ matrix.target }}
+          # CDKのPlatform.LINUX_AMD64と揃える
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_URI }}
+            ${{ needs.resolve.outputs.ecr_uri }}:${{ matrix.target }}
+          cache-from: type=gha,scope=backend-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=backend-${{ matrix.target }},ignore-error=true
+
+      # 可変タグではなくSHAタグで更新し、どのコミットが動いているかを追えるようにする
+      - name: Update Lambda
+        run: |
+          aws lambda update-function-code \
+            --function-name "${FUNCTION_NAME}" \
+            --image-uri "${IMAGE_URI}" \
+            --no-cli-pager
+          aws lambda wait function-updated-v2 --function-name "${FUNCTION_NAME}"

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,87 @@
+name: Deploy frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - apps/frontend/**
+      - .github/workflows/deploy-frontend.yml
+  workflow_dispatch:
+
+permissions:
+  # OIDCトークンの発行に必要。長期アクセスキーは持たせない
+  id-token: write
+  contents: read
+
+concurrency:
+  group: deploy-frontend
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          # 想定外のアカウントで解決された場合にデプロイ前で落とす
+          allowed-account-ids: ${{ secrets.AWS_ACCOUNT_ID }}
+
+      # Cognitoを作り直しても同期ずれが起きないよう、GitHub側へ値を複製せず
+      # DataStackの出力から取得する
+      - name: Resolve Cognito settings from DataStack
+        run: |
+          outputs=$(aws cloudformation describe-stacks \
+            --stack-name DataStack \
+            --query 'Stacks[0].Outputs' --output json)
+          read_output() {
+            echo "$outputs" | jq -er --arg key "$1" \
+              '.[] | select(.OutputKey == $key) | .OutputValue'
+          }
+          {
+            echo "VITE_COGNITO_AUTHORITY=$(read_output CognitoIssuer)"
+            echo "VITE_COGNITO_CLIENT_ID=$(read_output UserPoolClientId)"
+            echo "VITE_COGNITO_DOMAIN=$(read_output CognitoDomainUrl)"
+          } >> "$GITHUB_ENV"
+
+      - name: Resolve delivery targets from EdgeStack
+        run: |
+          outputs=$(aws cloudformation describe-stacks \
+            --stack-name EdgeStack \
+            --query 'Stacks[0].Outputs' --output json)
+          read_output() {
+            echo "$outputs" | jq -er --arg key "$1" \
+              '.[] | select(.OutputKey == $key) | .OutputValue'
+          }
+          {
+            echo "SPA_BUCKET_NAME=$(read_output SpaBucketName)"
+            echo "DISTRIBUTION_ID=$(read_output DistributionId)"
+          } >> "$GITHUB_ENV"
+
+      - name: Build
+        working-directory: apps/frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync apps/frontend/dist "s3://${SPA_BUCKET_NAME}" --delete
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${DISTRIBUTION_ID}" \
+            --paths '/*'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,8 @@ Target architecture (from `docs/architecture.md`; most of it is not yet implemen
 - **Auth**: Cognito Hosted UI with Authorization Code + PKCE. FastAPI only verifies JWTs via JWKS — never implement password handling or token issuance in the backend.
 - **Data**: DynamoDB single-table design (e.g. `PK=USER#123`, `SK=CHAT#<ULID>`) for documents, chats, and messages. IDs are ULIDs; GSI1 (`GSI1PK=DOC|CHAT`, `GSI1SK=<id>`) serves both cross-user lists and ID-only lookups. S3 Vectors metadata: `documentId` (filterable), `text`/`filename` (non-filterable).
 - **Zero fixed cost is a hard constraint**: no VPC, no NAT, no ECS/EC2/Aurora, no Provisioned Concurrency.
-- **CDK is planned as four stacks**: DataStack, AppStack, EdgeStack, CiStack (all but CiStack are implemented; see `cdk/README.md` for deploy prerequisites like the manual SSM SecureString setup and the `-c appDomain=` second pass). The SPA bucket lives in EdgeStack, not DataStack, because its OAC policy references the distribution.
+- **CDK is four stacks**: DataStack, AppStack, EdgeStack, CiStack (see `cdk/README.md` for deploy prerequisites like the manual SSM SecureString setup and the `-c appDomain=` second pass). The SPA bucket lives in EdgeStack, not DataStack, because its OAC policy references the distribution. CiStack holds only the GitHub Actions OIDC provider and deploy role.
+- **CI/CD**: `.github/workflows/ci.yml` validates PRs (frontend lint/format/build, backend ruff/pytest, cdk typecheck/jest); `deploy-frontend.yml` and `deploy-backend.yml` deploy on merge to `main`. Workflows never run `cdk deploy` — infrastructure changes are applied manually. CDK snapshot tests normalize asset hashes via `cdk/test/helpers.ts`, so backend-only edits no longer break `npm test`.
 - **Logging**: Lambda Powertools (structured logging, metrics, tracing); propagate the request ID across services.
 
 ## TypeScript Code Style

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,6 +1,6 @@
 # CDK
 
-AWS CDK (TypeScript) によるインフラ定義。スタック構成はDataStack / AppStack / EdgeStack(CiStackは今後実装)。認証のCognitoリソース(User Pool / Hosted UIドメイン / SPAクライアント)はDataStackで、SPA配信用S3バケットはOACのバケットポリシーと同居させるためEdgeStackで管理する。
+AWS CDK (TypeScript) によるインフラ定義。スタック構成はDataStack / AppStack / EdgeStack / CiStack。認証のCognitoリソース(User Pool / Hosted UIドメイン / SPAクライアント)はDataStackで、SPA配信用S3バケットはOACのバケットポリシーと同居させるためEdgeStackで管理する。CiStackはGitHub ActionsがOIDCで引き受けるデプロイ用ロールを持つ。
 
 ## コマンド
 
@@ -33,7 +33,7 @@ AppStackのLambdaはイメージアセット(`apps/backend/`のDockerfile、`web
 npx cdk deploy --all
 ```
 
-各スタックは前のスタックのリソースを参照するため、DataStack → AppStack → EdgeStackの順にデプロイされる。
+各スタックは前のスタックのリソースを参照するため、DataStack → AppStack → EdgeStack → CiStackの順にデプロイされる。
 
 スタック間の参照は`Fn::GetStackOutput`でデプロイ時に解決され、CloudFormationのExportを作らない。参照先のリソースを削除するスタック更新でも、Exportの削除がブロックされることはない。
 
@@ -49,12 +49,42 @@ npx cdk deploy DataStack -c appDomain=dxxxxxxxxxxxxx.cloudfront.net
 
 ### SPAの配信
 
-EdgeStackの`SpaBucketName`出力のバケットへビルド成果物を同期し、CloudFrontのキャッシュを無効化する。
+通常は`main`へのマージで`.github/workflows/deploy-frontend.yml`が実行するため、手動の操作は要らない。手元から反映する場合は、EdgeStackの`SpaBucketName`出力のバケットへビルド成果物を同期し、CloudFrontのキャッシュを無効化する。
 
 ```bash
 (cd ../apps/frontend && npm run build)
 aws s3 sync ../apps/frontend/dist s3://<SpaBucketName出力> --delete
 aws cloudfront create-invalidation --distribution-id <DistributionId出力> --paths '/*'
+```
+
+## CI/CD (CiStack)
+
+CiStackはGitHub ActionsのOIDC IDプロバイダと、Actionsが引き受けるデプロイ用ロール`event-driven-rag-github-actions`を作る。権限はSPAの同期、CloudFrontのキャッシュ無効化、ECRへのプッシュ、Lambdaのイメージ更新、スタック出力の読み取りに限定している。ワークフローは`cdk deploy`を行わないため、CloudFormationの更新権限は持たせていない。
+
+### GitHub側の設定
+
+CiStackのデプロイ後、`DeployRoleArn`出力とAWSアカウントIDをリポジトリのSecretsへ登録する。長期アクセスキーは登録しない。
+
+```bash
+npx cdk deploy CiStack
+gh secret set AWS_ROLE_ARN --body "<DeployRoleArn出力>"
+gh secret set AWS_ACCOUNT_ID --body "$(aws sts get-caller-identity --query Account --output text)"
+```
+
+### 信頼ポリシーのsubクレーム
+
+GitHubは2026年7月15日以降に作成されたリポジトリのOIDCトークンで、subクレームにownerとrepositoryの数値IDを含める(immutable subject claims)。`cdk/lib/ci-stack.ts`はこの形式のsubをハードコードしており、名前だけの旧形式では`AssumeRoleWithWebIdentity`が失敗する。フォークや別リポジトリで使う場合はIDを取り直して定数を差し替える。
+
+```bash
+gh api /repos/<owner>/<repo> --jq '{id, owner_id: .owner.id}'
+```
+
+### バックエンドのイメージ参照先
+
+AppStackのLambdaはイメージアセット(bootstrapのアセットリポジトリ)を参照する一方、CIは常設のECRリポジトリへプッシュして`update-function-code`で差し替える。そのため手動で`cdk deploy AppStack`を実行すると、参照先がアセットリポジトリへ戻る。イメージはローカルのソースからビルドし直されるのでコード自体は正しく、そのまま運用してよい。常設リポジトリへ戻したい場合はバックエンドのワークフローを再実行する。
+
+```bash
+gh workflow run deploy-backend.yml
 ```
 
 ## デプロイ後の設定

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib/core';
 import { AppStack } from '../lib/app-stack';
+import { CiStack } from '../lib/ci-stack';
 import { DataStack } from '../lib/data-stack';
 import { EdgeStack } from '../lib/edge-stack';
 
@@ -12,4 +13,6 @@ const dataStack = new DataStack(app, 'DataStack', { env });
 
 const appStack = new AppStack(app, 'AppStack', { env, dataStack });
 
-new EdgeStack(app, 'EdgeStack', { env, appStack });
+const edgeStack = new EdgeStack(app, 'EdgeStack', { env, appStack });
+
+new CiStack(app, 'CiStack', { env, dataStack, appStack, edgeStack });

--- a/cdk/lib/ci-stack.ts
+++ b/cdk/lib/ci-stack.ts
@@ -1,0 +1,149 @@
+import * as cdk from "aws-cdk-lib/core";
+import { Construct } from "constructs";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { AppStack } from "./app-stack";
+import { DataStack } from "./data-stack";
+import { EdgeStack } from "./edge-stack";
+
+const GITHUB_OIDC_URL = "https://token.actions.githubusercontent.com";
+const GITHUB_OIDC_AUDIENCE = "sts.amazonaws.com";
+
+// GitHubは2026-07-15以降に作成されたリポジトリのOIDCトークンで、subクレームに
+// ownerとrepositoryの数値IDを含める(immutable subject claims)。
+// 本リポジトリは2026-07-18作成の為この形式であり、名前だけの旧形式を書くと
+// AssumeRoleWithWebIdentityが失敗する。
+// IDの確認: gh api /repos/<owner>/<repo> --jq '{id, owner_id: .owner.id}'
+const GITHUB_OWNER = "ma-sa-shi";
+const GITHUB_OWNER_ID = 265779122;
+const GITHUB_REPOSITORY_NAME = "event-driven-rag";
+const GITHUB_REPOSITORY_ID = 1304510072;
+const DEPLOY_BRANCH = "main";
+
+export const DEPLOY_SUBJECT = `repo:${GITHUB_OWNER}@${GITHUB_OWNER_ID}/${GITHUB_REPOSITORY_NAME}@${GITHUB_REPOSITORY_ID}:ref:refs/heads/${DEPLOY_BRANCH}`;
+
+// ワークフローがARNを組み立てられるよう物理名を固定する
+export const DEPLOY_ROLE_NAME = "event-driven-rag-github-actions";
+
+export interface CiStackProps extends cdk.StackProps {
+  dataStack: DataStack;
+  appStack: AppStack;
+  edgeStack: EdgeStack;
+}
+
+/**
+ * CI/CD基盤スタック。
+ * GitHub ActionsがOIDCで引き受けるデプロイ用ロールを管理する。
+ * ワークフローは`cdk deploy`を行わずSPA同期とLambdaのイメージ更新だけを担う為、
+ * 権限はその2フローに必要な操作へ限定する。
+ */
+export class CiStack extends cdk.Stack {
+  public readonly deployRole: iam.Role;
+
+  constructor(scope: Construct, id: string, props: CiStackProps) {
+    super(scope, id, props);
+
+    const { dataStack, appStack, edgeStack } = props;
+
+    // L2のOpenIdConnectProviderはCustom Resource用のLambdaを増やす為、L1を直接使う。
+    // thumbprintListは省略する(IAMがGitHubの証明書から取得する)
+    const oidcProvider = new iam.CfnOIDCProvider(this, "GithubOidcProvider", {
+      url: GITHUB_OIDC_URL,
+      clientIdList: [GITHUB_OIDC_AUDIENCE],
+    });
+
+    // subはワイルドカードを使わず完全一致にし、他リポジトリ・他ブランチからの引き受けを塞ぐ
+    const githubPrincipal = new iam.WebIdentityPrincipal(oidcProvider.attrArn, {
+      StringEquals: {
+        "token.actions.githubusercontent.com:aud": GITHUB_OIDC_AUDIENCE,
+        "token.actions.githubusercontent.com:sub": DEPLOY_SUBJECT,
+      },
+    });
+
+    this.deployRole = new iam.Role(this, "DeployRole", {
+      roleName: DEPLOY_ROLE_NAME,
+      assumedBy: githubPrincipal,
+      description: "GitHub Actions deploy role (SPA sync / Lambda image update)",
+    });
+
+    // --- SPA配信(Build → S3 Sync → CloudFront Invalidation) ---
+    // s3 syncは差分判定でバケット一覧とオブジェクト取得を行う
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["s3:ListBucket", "s3:GetBucketLocation"],
+        resources: [edgeStack.spaBucket.bucketArn],
+      }),
+    );
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        // --deleteで消える古いアセットがある為DeleteObjectも要る
+        actions: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+        resources: [edgeStack.spaBucket.arnForObjects("*")],
+      }),
+    );
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["cloudfront:CreateInvalidation"],
+        resources: [edgeStack.distribution.distributionArn],
+      }),
+    );
+
+    // --- バックエンド(Docker Build → ECR Push → Lambda Update) ---
+    // GetAuthorizationTokenはリソース単位のスコープを取れない唯一の操作
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["ecr:GetAuthorizationToken"],
+        resources: ["*"],
+      }),
+    );
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage",
+          // buildxのキャッシュ参照で既存イメージを読む
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer",
+        ],
+        resources: [appStack.repository.repositoryArn],
+      }),
+    );
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        // GetFunctionConfigurationは更新完了を待つwaiterが使う
+        actions: [
+          "lambda:UpdateFunctionCode",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+        ],
+        resources: [
+          appStack.apiFunction.functionArn,
+          appStack.chatFunction.functionArn,
+          appStack.ingestFunction.functionArn,
+        ],
+      }),
+    );
+
+    // --- スタック出力の読み取り ---
+    // バケット名や関数名をGitHub側へ複製せず、デプロイのたびに出力から取得する
+    this.deployRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["cloudformation:DescribeStacks"],
+        resources: [dataStack, appStack, edgeStack].map((stack) =>
+          this.formatArn({
+            service: "cloudformation",
+            resource: "stack",
+            // スタックARNの末尾はCloudFormationが払い出すUUIDになる
+            resourceName: `${stack.stackName}/*`,
+          }),
+        ),
+      }),
+    );
+
+    new cdk.CfnOutput(this, "DeployRoleArn", {
+      value: this.deployRole.roleArn,
+    });
+  }
+}

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -111,7 +111,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:b3c97b264e278c8020020761c5846ce3321e59b0f94f5be5c205d284e2cd0c70",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:<ASSET_HASH>",
           },
         },
         "Environment": {
@@ -298,7 +298,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:bdbc37d71cab34a05b0c5508ccf9c93c49cac674d8e41265cf4d95ef12922c45",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:<ASSET_HASH>",
           },
         },
         "Environment": {
@@ -531,7 +531,7 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "Code": {
           "ImageUri": {
-            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:6144fd29aecb1fd279927039245fb040e0b97deebe8ad726886143d103a564d2",
+            "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:<ASSET_HASH>",
           },
         },
         "Environment": {

--- a/cdk/test/__snapshots__/ci-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/ci-stack.test.ts.snap
@@ -1,0 +1,264 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`スナップショット 1`] = `
+{
+  "Outputs": {
+    "DeployRoleArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "DeployRole885297C3",
+          "Arn",
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "DeployRole885297C3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                  "token.actions.githubusercontent.com:sub": "repo:ma-sa-shi@265779122/event-driven-rag@1304510072:ref:refs/heads/main",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": {
+                  "Fn::GetAtt": [
+                    "GithubOidcProvider",
+                    "Arn",
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": "GitHub Actions deploy role (SPA sync / Lambda image update)",
+        "RoleName": "event-driven-rag-github-actions",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DeployRoleDefaultPolicyDC930F96": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "TestEdgeStack:ExportsOutputFnGetAttSpaBucket48E1059FArn2DCBB8A5",
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::ImportValue": "TestEdgeStack:ExportsOutputFnGetAttSpaBucket48E1059FArn2DCBB8A5",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "cloudfront:CreateInvalidation",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":cloudfront::",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":distribution/",
+                    {
+                      "Fn::ImportValue": "TestEdgeStack:ExportsOutputRefDistribution830FAC524DF81588",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:PutImage",
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "TestAppStack:ExportsOutputFnGetAttRepository22E53BBDArn3AD4E30B",
+              },
+            },
+            {
+              "Action": [
+                "lambda:UpdateFunctionCode",
+                "lambda:GetFunction",
+                "lambda:GetFunctionConfiguration",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::ImportValue": "TestAppStack:ExportsOutputFnGetAttApiFunctionCE271BD4Arn4729005E",
+                },
+                {
+                  "Fn::ImportValue": "TestAppStack:ExportsOutputFnGetAttChatFunction3D7C447EArn52D22D75",
+                },
+                {
+                  "Fn::ImportValue": "TestAppStack:ExportsOutputFnGetAttIngestFunction4B2F2EB2ArnCFA1AFB0",
+                },
+              ],
+            },
+            {
+              "Action": "cloudformation:DescribeStacks",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudformation:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/TestDataStack/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudformation:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/TestAppStack/*",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":cloudformation:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":stack/TestEdgeStack/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DeployRoleDefaultPolicyDC930F96",
+        "Roles": [
+          {
+            "Ref": "DeployRole885297C3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GithubOidcProvider": {
+      "Properties": {
+        "ClientIdList": [
+          "sts.amazonaws.com",
+        ],
+        "Url": "https://token.actions.githubusercontent.com",
+      },
+      "Type": "AWS::IAM::OIDCProvider",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/cdk/test/__snapshots__/data-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/data-stack.test.ts.snap
@@ -88,7 +88,7 @@ exports[`スナップショット 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip",
+          "S3Key": "<ASSET_HASH>.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/cdk/test/__snapshots__/edge-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/edge-stack.test.ts.snap
@@ -39,7 +39,7 @@ exports[`スナップショット 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip",
+          "S3Key": "<ASSET_HASH>.zip",
         },
         "Description": {
           "Fn::Join": [

--- a/cdk/test/app-stack.test.ts
+++ b/cdk/test/app-stack.test.ts
@@ -6,6 +6,7 @@ import {
   OPENAI_API_KEY_PARAMETER_NAME,
 } from '../lib/app-stack';
 import { DataStack } from '../lib/data-stack';
+import { normalizeAssetHashes } from './helpers';
 
 let template: Template;
 
@@ -308,8 +309,6 @@ describe('IAM', () => {
   });
 });
 
-// backendソースの変更でイメージアセットハッシュが変わるため、
-// スナップショットはbackend編集のたびに更新される(意図した挙動)
 test('スナップショット', () => {
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(normalizeAssetHashes(template)).toMatchSnapshot();
 });

--- a/cdk/test/ci-stack.test.ts
+++ b/cdk/test/ci-stack.test.ts
@@ -1,0 +1,184 @@
+import * as cdk from 'aws-cdk-lib/core';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { AppStack } from '../lib/app-stack';
+import { CiStack, DEPLOY_ROLE_NAME, DEPLOY_SUBJECT } from '../lib/ci-stack';
+import { DataStack } from '../lib/data-stack';
+import { EdgeStack } from '../lib/edge-stack';
+import { normalizeAssetHashes } from './helpers';
+
+const OIDC_CLAIM_PREFIX = 'token.actions.githubusercontent.com';
+
+let template: Template;
+
+beforeAll(() => {
+  const app = new cdk.App();
+  const dataStack = new DataStack(app, 'TestDataStack');
+  const appStack = new AppStack(app, 'TestAppStack', { dataStack });
+  const edgeStack = new EdgeStack(app, 'TestEdgeStack', { appStack });
+  const ciStack = new CiStack(app, 'TestCiStack', {
+    dataStack,
+    appStack,
+    edgeStack,
+  });
+  template = Template.fromStack(ciStack);
+});
+
+// デプロイロールのインラインポリシーのステートメント一覧
+function policyStatements() {
+  const policies = template.findResources('AWS::IAM::Policy');
+  const [policy] = Object.values(policies);
+  return policy.Properties.PolicyDocument.Statement as {
+    Action: string | string[];
+    Resource: unknown;
+  }[];
+}
+
+function statementFor(action: string) {
+  const matched = policyStatements().filter((statement) =>
+    [statement.Action].flat().includes(action),
+  );
+  expect(matched).toHaveLength(1);
+  return matched[0];
+}
+
+describe('OIDCプロバイダ', () => {
+  test('GitHub Actionsのプロバイダが作成される', () => {
+    template.resourceCountIs('AWS::IAM::OIDCProvider', 1);
+    template.hasResourceProperties('AWS::IAM::OIDCProvider', {
+      Url: 'https://token.actions.githubusercontent.com',
+      ClientIdList: ['sts.amazonaws.com'],
+    });
+  });
+
+  test('Custom Resourceを使わない(Lambdaを作らない)', () => {
+    template.resourceCountIs('AWS::Lambda::Function', 0);
+  });
+});
+
+describe('デプロイロールの信頼ポリシー', () => {
+  test('OIDCプロバイダからのWebIdentityのみを受け入れる', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      RoleName: DEPLOY_ROLE_NAME,
+      AssumeRolePolicyDocument: {
+        Statement: [
+          Match.objectLike({
+            Action: 'sts:AssumeRoleWithWebIdentity',
+            Effect: 'Allow',
+            Principal: {
+              Federated: { 'Fn::GetAtt': ['GithubOidcProvider', 'Arn'] },
+            },
+          }),
+        ],
+      },
+    });
+  });
+
+  test('audとsubをリポジトリとブランチで完全一致に制限する', () => {
+    template.hasResourceProperties('AWS::IAM::Role', {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          Match.objectLike({
+            Condition: {
+              StringEquals: {
+                [`${OIDC_CLAIM_PREFIX}:aud`]: 'sts.amazonaws.com',
+                [`${OIDC_CLAIM_PREFIX}:sub`]: DEPLOY_SUBJECT,
+              },
+            },
+          }),
+        ],
+      },
+    });
+  });
+
+  test('subはimmutable subject claims形式で、ワイルドカードを含まない', () => {
+    // 2026-07-15以降に作成されたリポジトリはowner IDとrepository IDをsubに含む。
+    // 旧形式のままだとAssumeRoleWithWebIdentityが失敗する
+    expect(DEPLOY_SUBJECT).toBe(
+      'repo:ma-sa-shi@265779122/event-driven-rag@1304510072:ref:refs/heads/main',
+    );
+    expect(DEPLOY_SUBJECT).not.toContain('*');
+  });
+
+  test('StringLikeによる緩い条件を持たない', () => {
+    const roles = template.findResources('AWS::IAM::Role');
+    const [role] = Object.values(roles);
+    const [statement] = role.Properties.AssumeRolePolicyDocument.Statement;
+    expect(Object.keys(statement.Condition)).toEqual(['StringEquals']);
+  });
+});
+
+describe('デプロイロールの権限', () => {
+  test('Resourceが*なのはecr:GetAuthorizationTokenだけ', () => {
+    // GetAuthorizationTokenはリソース単位のスコープを取れない。
+    // それ以外が*に広がる退行を防ぐ
+    const wildcard = policyStatements().filter(
+      (statement) => statement.Resource === '*',
+    );
+    expect(wildcard).toHaveLength(1);
+    expect(wildcard[0].Action).toBe('ecr:GetAuthorizationToken');
+  });
+
+  test('SPAバケットへの同期に必要な権限を持つ', () => {
+    expect(statementFor('s3:ListBucket').Action).toEqual(
+      expect.arrayContaining(['s3:GetBucketLocation', 's3:ListBucket']),
+    );
+    expect(statementFor('s3:PutObject').Action).toEqual(
+      expect.arrayContaining([
+        's3:DeleteObject',
+        's3:GetObject',
+        's3:PutObject',
+      ]),
+    );
+  });
+
+  test('CloudFrontはCreateInvalidationのみ許可する', () => {
+    const statement = statementFor('cloudfront:CreateInvalidation');
+    expect(statement.Action).toBe('cloudfront:CreateInvalidation');
+  });
+
+  test('ECRのpush権限は常設リポジトリへスコープされる', () => {
+    const statement = statementFor('ecr:PutImage');
+    expect(statement.Resource).not.toBe('*');
+    expect(JSON.stringify(statement.Resource)).toContain('Repository');
+  });
+
+  test('Lambdaの更新は3関数へスコープされる', () => {
+    const statement = statementFor('lambda:UpdateFunctionCode');
+    expect(statement.Resource).toHaveLength(3);
+    const resources = JSON.stringify(statement.Resource);
+    for (const fn of ['ApiFunction', 'ChatFunction', 'IngestFunction']) {
+      expect(resources).toContain(fn);
+    }
+  });
+
+  test('DescribeStacksは3スタックへスコープされる', () => {
+    const statement = statementFor('cloudformation:DescribeStacks');
+    expect(statement.Resource).toHaveLength(3);
+    const resources = JSON.stringify(statement.Resource);
+    for (const stackName of ['TestDataStack', 'TestAppStack', 'TestEdgeStack']) {
+      expect(resources).toContain(`stack/${stackName}/*`);
+    }
+  });
+
+  test('cdk deployは行わない為、CloudFormationの更新権限を持たない', () => {
+    const actions = policyStatements().flatMap((statement) =>
+      [statement.Action].flat(),
+    );
+    expect(actions).not.toContain('cloudformation:CreateStack');
+    expect(actions).not.toContain('cloudformation:UpdateStack');
+    expect(actions).not.toContain('sts:AssumeRole');
+    expect(actions).not.toContain('iam:PassRole');
+  });
+});
+
+describe('出力', () => {
+  test('DeployRoleArnを出力する', () => {
+    template.hasOutput('DeployRoleArn', {
+      Value: { 'Fn::GetAtt': [Match.stringLikeRegexp('DeployRole'), 'Arn'] },
+    });
+  });
+});
+
+test('スナップショット', () => {
+  expect(normalizeAssetHashes(template)).toMatchSnapshot();
+});

--- a/cdk/test/data-stack.test.ts
+++ b/cdk/test/data-stack.test.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib/core';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { DataStack } from '../lib/data-stack';
+import { normalizeAssetHashes } from './helpers';
 
 let template: Template;
 
@@ -203,5 +204,5 @@ describe('Cognito', () => {
 });
 
 test('スナップショット', () => {
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(normalizeAssetHashes(template)).toMatchSnapshot();
 });

--- a/cdk/test/edge-stack.test.ts
+++ b/cdk/test/edge-stack.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import { AppStack } from '../lib/app-stack';
 import { DataStack } from '../lib/data-stack';
 import { EdgeStack } from '../lib/edge-stack';
+import { normalizeAssetHashes } from './helpers';
 
 // CloudFrontのマネージドポリシーID(固定値)
 const CACHING_DISABLED = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad';
@@ -180,5 +181,5 @@ describe('S3 OAC', () => {
 });
 
 test('スナップショット', () => {
-  expect(template.toJSON()).toMatchSnapshot();
+  expect(normalizeAssetHashes(template)).toMatchSnapshot();
 });

--- a/cdk/test/helpers.ts
+++ b/cdk/test/helpers.ts
@@ -1,0 +1,31 @@
+import { Template } from 'aws-cdk-lib/assertions';
+
+// CDKのアセットハッシュはソース内容から算出される為、backendを1行直すだけで
+// ImageUriが変わり、無関係なスナップショットが落ちる。
+// 対象はコンテナイメージのImageUri、Lambdaアセットの<hash>.zip、aws:asset:pathメタデータで、
+// いずれも64桁の16進数として現れる。CDKテンプレート中の他の値がこの形になることはない
+const ASSET_HASH_PATTERN = /\b[0-9a-f]{64}\b/g;
+const ASSET_HASH_PLACEHOLDER = '<ASSET_HASH>';
+
+function replaceHashes(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(ASSET_HASH_PATTERN, ASSET_HASH_PLACEHOLDER);
+  }
+  if (Array.isArray(value)) {
+    return value.map(replaceHashes);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, replaceHashes(child)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * アセットハッシュを固定文字列へ置換したテンプレートを返す。
+ * Templateインスタンスは他のアサーションと共有される為、複製してから置換する。
+ */
+export function normalizeAssetHashes(template: Template): unknown {
+  return replaceHashes(template.toJSON());
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -437,9 +437,9 @@ textとfilenameはフィルタ不可のMetadataとして登録する。フィル
 
 ### 9.1 CDKスタック構成
 
-インフラはAWS CDKで管理し、DataStack、AppStack、EdgeStack、CiStackの4スタックへ分割する(CiStackは未実装。[12. 開発計画](#12-開発計画)を参照)。
+インフラはAWS CDKで管理し、DataStack、AppStack、EdgeStack、CiStackの4スタックへ分割する。
 
-分割の基準はリソースのライフサイクルである。ユーザーやドキュメントが蓄積されるステートフルなリソースをDataStackへまとめ、入れ替えの多いアプリケーション層と分離する。認証のCognitoも、ユーザーが蓄積されるためDataStackで管理する。
+分割の基準はリソースのライフサイクルである。ユーザーやドキュメントが蓄積されるステートフルなリソースをDataStackへまとめ、入れ替えの多いアプリケーション層と分離する。認証のCognitoも、ユーザーが蓄積されるためDataStackで管理する。CiStackはGitHub ActionsのOIDC IDプロバイダとデプロイ用IAMロールだけを持ち、アプリケーションのリソースを含まない。
 
 SPA配信用S3バケットは例外としてEdgeStackで管理する。アクセス制御にOACを用いるため、バケットポリシーがCloudFrontディストリビューションを参照するからである。
 
@@ -522,7 +522,13 @@ Request IDを全サービスで引き継ぎ、1リクエストの処理をサー
 
 ### 10.2 CI/CD
 
-CI/CDはGitHub Actionsで構成する。
+CI/CDはGitHub Actionsで構成する。プルリクエストではlintとテストによる検証のみを行い、`main`へのマージでデプロイする。
+
+AWSへの認証はOIDCとし、長期アクセスキーはGitHubへ保存しない。CiStackが持つデプロイ用ロールの信頼ポリシーは、リポジトリと`main`ブランチに完全一致で限定する。
+
+ワークフローが行うのはアプリケーションコードの反映だけであり、インフラ定義の変更は`cdk deploy`を手動で実行する。この切り分けにより、CloudFrontのドメイン名を渡す`appDomain`コンテキスト([9.1](#91-cdkスタック構成))をワークフローが扱う必要がなくなり、デプロイ用ロールにCloudFormationの更新権限も持たせずに済む。
+
+デプロイに必要なバケット名や関数名はGitHub側へ複製せず、各スタックの出力を`DescribeStacks`で都度取得する。SPAのビルド時に埋め込むCognitoの設定値も同様に扱い、Cognitoを作り直しても同期ずれが起きないようにする。
 
 フロントエンドのデプロイフローを次に示す。
 


### PR DESCRIPTION
CiStackとGitHub Actionsのワークフローを追加し、architecture.md 10.2のデプロイフローを自動化する。PRでは検証のみを行い、mainへのマージでSPAとLambdaイメージを反映する。認証はOIDCとし、長期アクセスキーはGitHubへ保存していない。

ワークフローはcdk deployを実行せず、インフラ定義の変更は手動で適用する。これによりappDomainコンテキストをワークフローが扱わずに済み、デプロイ用ロールからCloudFormationの更新権限も外せている。バケット名やLambda名、SPAへ埋め込むCognitoの設定値もGitHub Secretsへ複製せずDescribeStacksで都度取得しており、GitHub側へ登録するのはロールARNとアカウントIDのみ。

信頼ポリシーのsubクレームは、ownerとrepositoryの数値IDを含む形式(immutable subject claims)でハードコードしている。名前だけの旧形式ではAssumeRoleWithWebIdentityが失敗するため、IDを取り直す手順をcdk/README.mdへ残した。手動でcdk deploy AppStackを実行するとLambdaのイメージ参照先がCIの常設ECRからアセットリポジトリへ戻る点も、併せて記載した。

CDKのスナップショットはアセットハッシュを正規化してから取得するようにした。従来はLambdaイメージのハッシュを含んでいたため、バックエンドを1行直すだけで無関係なスナップショットが落ち、更新が必要だった。

test(cdk): normalize asset hashes in stack snapshots

feat(cdk): add CiStack with a GitHub Actions OIDC deploy role

ci: add PR validation and deploy workflows
 
docs: document the CI/CD pipeline

fix(ci): pin setup-uv to an existing tag

Closes #33 