### PR TITLE
Disable provenance on the backend image build

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -78,6 +78,8 @@ jobs:
           # CDKのPlatform.LINUX_AMD64と揃える
           platforms: linux/amd64
           push: true
+          # 既定のprovenance attestationはOCI image indexを作り、Lambdaが受け付けない
+          provenance: false
           tags: |
             ${{ steps.target.outputs.image_uri }}
             ${{ steps.target.outputs.moving_tag_uri }}


### PR DESCRIPTION
`update-function-code`が3関数とも`InvalidParameterValueException: The image
manifest, config or layer media type for the source image ... is not supported`
で失敗する。`docker/build-push-action`は既定でprovenance attestationを付け、
成果物が単一イメージではなくOCI image indexになる為、Lambdaが受け付けない。

`provenance: false`を指定し、単一イメージとしてプッシュする。イメージのビルドと
ECRへのプッシュ自体は成功している為、変更はこの1行のみ。

fix(ci): disable provenance on the backend image build

Closes #38 