### PR TITLE
Fix Lambda permissions for ECR image access

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -54,6 +54,28 @@ export class AppStack extends cdk.Stack {
       emptyOnDelete: true,
     });
 
+    // bootstrapのアセットリポジトリと違い、常設リポジトリのポリシーは自分で用意する。
+    // Lambdaはポリシーが無い場合に自動追加を試みるが、それにはデプロイ用ロールへ
+    // ecr:GetRepositoryPolicy / SetRepositoryPolicyが要る為、明示的に付ける
+    this.repository.addToResourcePolicy(
+      new iam.PolicyStatement({
+        sid: "LambdaECRImageRetrievalPolicy",
+        principals: [new iam.ServicePrincipal("lambda.amazonaws.com")],
+        actions: ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer"],
+        // サービスプリンシパルを自アカウントの関数へ限定する
+        conditions: {
+          ArnLike: {
+            "aws:sourceARN": this.formatArn({
+              service: "lambda",
+              resource: "function",
+              resourceName: "*",
+              arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME,
+            }),
+          },
+        },
+      }),
+    );
+
     const backendPath = path.join(__dirname, "..", "..", "apps", "backend");
 
     // web: Lambda Web Adapter + uvicorn(api-fn)

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -759,6 +759,46 @@ exports[`スナップショット 1`] = `
       "DeletionPolicy": "Delete",
       "Properties": {
         "EmptyOnDelete": true,
+        "RepositoryPolicyText": {
+          "Statement": [
+            {
+              "Action": [
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer",
+              ],
+              "Condition": {
+                "ArnLike": {
+                  "aws:sourceARN": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":lambda:",
+                        {
+                          "Ref": "AWS::Region",
+                        },
+                        ":",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":function:*",
+                      ],
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+              "Sid": "LambdaECRImageRetrievalPolicy",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
       },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",

--- a/cdk/test/app-stack.test.ts
+++ b/cdk/test/app-stack.test.ts
@@ -36,6 +36,20 @@ describe('ECR', () => {
       DeletionPolicy: 'Delete',
     });
   });
+
+  test('Lambdaがイメージを取得できるリポジトリポリシーを持つ', () => {
+    template.hasResourceProperties('AWS::ECR::Repository', {
+      RepositoryPolicyText: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Effect: 'Allow',
+            Principal: { Service: 'lambda.amazonaws.com' },
+            Action: ['ecr:BatchGetImage', 'ecr:GetDownloadUrlForLayer'],
+          }),
+        ]),
+      },
+    });
+  });
 });
 
 describe('Lambda', () => {


### PR DESCRIPTION
`update-function-code`が3関数とも`AccessDeniedException: Lambda does not have
permission to access the ECR image`で失敗する。CI用の常設ECRリポジトリにリソース
ポリシーが無く、Lambdaサービスがイメージを取得できない。bootstrapのアセット
リポジトリは同等のポリシーを持つ為、アセット参照のままでは表面化していなかった。

ポリシーが無い場合、Lambdaは自動追加を試みるが、それには呼び出し元が
`ecr:GetRepositoryPolicy` / `SetRepositoryPolicy`を持つ必要がある。デプロイ用
ロールにこれらを与えるより、CDKで明示する方を選んだ。`aws:sourceARN`で
サービスプリンシパルを自アカウントの関数に限定している。

マージ後、`npx cdk deploy AppStack`の手動実行が必要になる。

fix(cdk): let Lambda pull from the standing ECR repository

Closes #40 