### PR TITLE
Set a Content Security Policy on the SPA

### DIFF
--- a/apps/backend/app/storage.py
+++ b/apps/backend/app/storage.py
@@ -1,9 +1,15 @@
 import boto3
+from botocore.config import Config
 
 # presigned URLはLambdaロールで署名されるため、実行ロールに対象操作の権限が必要
 # 長すぎるとURL漏洩時のリスクが増すため15分に制限
 UPLOAD_URL_EXPIRES_IN = 900
 DOWNLOAD_URL_EXPIRES_IN = 900
+
+# 既定のboto3はリージョンを落としたグローバルエンドポイント(<bucket>.s3.amazonaws.com)へ
+# 書き換え、非推奨のSigV2で署名する。SPAはこのURLへブラウザから直接PUTするため、
+# 発行先のホストはCloudFrontのCSP connect-src(設計書9.2)と一致させる必要がある
+_PRESIGN_CONFIG = Config(signature_version="s3v4", s3={"addressing_style": "virtual"})
 
 
 class DocumentStorage:
@@ -11,7 +17,7 @@ class DocumentStorage:
 
     def __init__(self, bucket_name: str) -> None:
         self._bucket_name = bucket_name
-        self._client = boto3.client("s3")
+        self._client = boto3.client("s3", config=_PRESIGN_CONFIG)
 
     def presign_put(self, key: str, content_type: str | None = None) -> str:
         params: dict = {"Bucket": self._bucket_name, "Key": key}

--- a/apps/backend/tests/test_storage.py
+++ b/apps/backend/tests/test_storage.py
@@ -1,0 +1,28 @@
+"""Presigned URLの発行先ホストはCloudFrontのCSP connect-srcと対になる契約であり、
+boto3の既定値ではグローバルエンドポイントへ書き換わるため、ここで形を固定する。"""
+
+from urllib.parse import parse_qs, urlparse
+
+from app.storage import DocumentStorage
+from tests.conftest import BUCKET_NAME
+
+KEY = "documents/user-id/doc-id/architecture.md"
+
+
+def test_presign_put_uses_regional_virtual_hosted_url():
+    url = urlparse(DocumentStorage(BUCKET_NAME).presign_put(KEY))
+    # CDKがCSPへ載せるbucketRegionalDomainNameと同じ形
+    assert url.netloc == f"{BUCKET_NAME}.s3.ap-northeast-1.amazonaws.com"
+    assert parse_qs(url.query)["X-Amz-Algorithm"] == ["AWS4-HMAC-SHA256"]
+
+
+def test_presign_get_uses_regional_virtual_hosted_url():
+    url = urlparse(DocumentStorage(BUCKET_NAME).presign_get(KEY))
+    assert url.netloc == f"{BUCKET_NAME}.s3.ap-northeast-1.amazonaws.com"
+    assert parse_qs(url.query)["X-Amz-Algorithm"] == ["AWS4-HMAC-SHA256"]
+
+
+def test_presign_put_signs_the_content_type():
+    url = urlparse(DocumentStorage(BUCKET_NAME).presign_put(KEY, "text/plain"))
+    # SPAは発行時と同じContent-Typeをヘッダーで送る必要がある
+    assert parse_qs(url.query)["X-Amz-SignedHeaders"] == ["content-type;host"]

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -33,6 +33,7 @@ const appStack = new AppStack(app, 'AppStack', { env, dataStack });
 const edgeStack = new EdgeStack(app, 'EdgeStack', {
   env,
   appStack,
+  dataStack,
   customDomain: { domainName: appDomain, certificate: certificateStack.certificate },
 });
 

--- a/cdk/lib/edge-stack.ts
+++ b/cdk/lib/edge-stack.ts
@@ -5,9 +5,12 @@ import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import { AppStack } from "./app-stack";
+import { DataStack } from "./data-stack";
 
 export interface EdgeStackProps extends cdk.StackProps {
   appStack: AppStack;
+  // CSPのconnect-srcにCognitoとドキュメントバケットのオリジンを載せる為に参照する
+  dataStack: DataStack;
   // 代替ドメイン名と証明書は必ず対で必要な為、1つのプロパティにまとめる
   customDomain?: {
     domainName: string;
@@ -29,7 +32,7 @@ export class EdgeStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: EdgeStackProps) {
     super(scope, id, props);
 
-    const { appStack, customDomain } = props;
+    const { appStack, dataStack, customDomain } = props;
 
     // SPA静的ファイル配信用バケット。CloudFront OAC経由でのみ読み取れる
     this.spaBucket = new s3.Bucket(this, "SpaBucket", {
@@ -89,11 +92,56 @@ function handler(event) {
 `),
     });
 
+    // トークンをlocalStorageへ置く判断(ADR-0010)の緩和策。XSSが起きても外部へ送信させない。
+    // SPAが同一オリジン外へ出す通信はこの3つだけで、他は全てCloudFront経由に収まる(設計書9.2)。
+    // issuerの末尾の'/'は必須。CSPのパスは末尾がスラッシュのときだけ前方一致になり、
+    // 付けないと完全一致となってoidc-client-tsが読む/.well-known配下が弾かれる
+    const connectSources = [
+      "'self'",
+      `${dataStack.userPool.userPoolProviderUrl}/`,
+      dataStack.userPoolDomain.baseUrl(),
+      `https://${dataStack.documentsBucket.bucketRegionalDomainName}`,
+    ];
+
+    // object-src・base-uri・form-actionはdefault-srcのフォールバックが効かない為、個別に指定する
+    const contentSecurityPolicy = [
+      "default-src 'self'",
+      `connect-src ${connectSources.join(" ")}`,
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+    ].join("; ");
+
+    const spaResponseHeaders = new cloudfront.ResponseHeadersPolicy(
+      this,
+      "SpaResponseHeaders",
+      {
+        securityHeadersBehavior: {
+          contentSecurityPolicy: { contentSecurityPolicy, override: true },
+          // preloadはapexドメイン単位の登録になる為、サブドメイン配信の本システムでは付けない
+          strictTransportSecurity: {
+            accessControlMaxAge: cdk.Duration.days(730),
+            includeSubdomains: true,
+            override: true,
+          },
+          contentTypeOptions: { override: true },
+          referrerPolicy: {
+            referrerPolicy:
+              cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            override: true,
+          },
+        },
+      },
+    );
+
     this.distribution = new cloudfront.Distribution(this, "Distribution", {
       defaultBehavior: {
         origin: spaOrigin,
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        // APIのJSONレスポンスにCSPは効かない為、SPAを返す本ビヘイビアにのみ適用する
+        responseHeadersPolicy: spaResponseHeaders,
         functionAssociations: [
           {
             function: spaRouterFunction,

--- a/cdk/test/__snapshots__/edge-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/edge-stack.test.ts.snap
@@ -142,6 +142,9 @@ exports[`スナップショット 1`] = `
                 },
               },
             ],
+            "ResponseHeadersPolicyId": {
+              "Ref": "SpaResponseHeadersBB5A00A9",
+            },
             "TargetOriginId": "TestEdgeStackDistributionOrigin18490990F",
             "ViewerProtocolPolicy": "redirect-to-https",
           },
@@ -519,6 +522,63 @@ exports[`スナップショット 1`] = `
         },
       },
       "Type": "AWS::S3::BucketPolicy",
+    },
+    "SpaResponseHeadersBB5A00A9": {
+      "Properties": {
+        "ResponseHeadersPolicyConfig": {
+          "Name": "TestEdgeStackSpaResponseHeaders9C64C845",
+          "SecurityHeadersConfig": {
+            "ContentSecurityPolicy": {
+              "ContentSecurityPolicy": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "default-src 'self'; connect-src 'self' ",
+                    {
+                      "Fn::GetStackOutput": {
+                        "OutputName": "PublishOutputFnGetAttUserPool6BA7E5F2ProviderURL015E0733",
+                        "Region": "ap-northeast-1",
+                        "StackName": "TestDataStack",
+                      },
+                    },
+                    "/ https://",
+                    {
+                      "Fn::GetStackOutput": {
+                        "OutputName": "PublishOutputRefUserPoolHostedUiDomainE021B0B632E878CC",
+                        "Region": "ap-northeast-1",
+                        "StackName": "TestDataStack",
+                      },
+                    },
+                    ".auth.ap-northeast-1.amazoncognito.com https://",
+                    {
+                      "Fn::GetStackOutput": {
+                        "OutputName": "PublishOutputFnGetAttDocumentsBucket9EC9DEB9RegionalDomainName36DBBEFC",
+                        "Region": "ap-northeast-1",
+                        "StackName": "TestDataStack",
+                      },
+                    },
+                    "; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'",
+                  ],
+                ],
+              },
+              "Override": true,
+            },
+            "ContentTypeOptions": {
+              "Override": true,
+            },
+            "ReferrerPolicy": {
+              "Override": true,
+              "ReferrerPolicy": "strict-origin-when-cross-origin",
+            },
+            "StrictTransportSecurity": {
+              "AccessControlMaxAgeSec": 63072000,
+              "IncludeSubdomains": true,
+              "Override": true,
+            },
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::ResponseHeadersPolicy",
     },
     "SpaRouterEC02D323": {
       "Properties": {

--- a/cdk/test/ci-stack.test.ts
+++ b/cdk/test/ci-stack.test.ts
@@ -14,7 +14,7 @@ beforeAll(() => {
   const app = new cdk.App();
   const dataStack = new DataStack(app, 'TestDataStack');
   const appStack = new AppStack(app, 'TestAppStack', { dataStack });
-  const edgeStack = new EdgeStack(app, 'TestEdgeStack', { appStack });
+  const edgeStack = new EdgeStack(app, 'TestEdgeStack', { appStack, dataStack });
   const ciStack = new CiStack(app, 'TestCiStack', {
     dataStack,
     appStack,

--- a/cdk/test/edge-stack.test.ts
+++ b/cdk/test/edge-stack.test.ts
@@ -30,7 +30,9 @@ function synthEdgeStack(withCustomDomain: boolean) {
   const appStack = new AppStack(app, 'TestAppStack', { env, dataStack });
 
   if (!withCustomDomain) {
-    return Template.fromStack(new EdgeStack(app, 'TestEdgeStack', { env, appStack }));
+    return Template.fromStack(
+      new EdgeStack(app, 'TestEdgeStack', { env, appStack, dataStack }),
+    );
   }
 
   const certificateStack = new CertificateStack(app, 'TestCertificateStack', {
@@ -40,6 +42,7 @@ function synthEdgeStack(withCustomDomain: boolean) {
   const edgeStack = new EdgeStack(app, 'TestEdgeStack', {
     env,
     appStack,
+    dataStack,
     customDomain: {
       domainName: DOMAIN_NAME,
       certificate: certificateStack.certificate,
@@ -189,6 +192,65 @@ describe('SPAルーティング', () => {
   test('カスタムエラーレスポンスは使わない', () => {
     // ディストリビューション全体に効く為、FastAPIの403/404 JSONまで書き換えてしまう
     expect(distributionConfig.CustomErrorResponses).toBeUndefined();
+  });
+});
+
+describe('レスポンスヘッダー', () => {
+  function securityHeadersConfig() {
+    const [policy] = Object.values(
+      template.findResources('AWS::CloudFront::ResponseHeadersPolicy'),
+    );
+    return policy.Properties.ResponseHeadersPolicyConfig.SecurityHeadersConfig;
+  }
+
+  test('SPAのデフォルトビヘイビアにのみポリシーを適用する', () => {
+    template.resourceCountIs('AWS::CloudFront::ResponseHeadersPolicy', 1);
+    expect(distributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId).toBeDefined();
+    // APIのJSONレスポンスにCSPは効かない
+    for (const behavior of distributionConfig.CacheBehaviors) {
+      expect(behavior.ResponseHeadersPolicyId).toBeUndefined();
+    }
+  });
+
+  test('CSPはインラインを許可せずフレーム埋め込みを禁止する(ADR-0010)', () => {
+    const csp = JSON.stringify(
+      securityHeadersConfig().ContentSecurityPolicy.ContentSecurityPolicy,
+    );
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).not.toContain('unsafe-inline');
+    expect(csp).toContain("frame-ancestors 'none'");
+    // default-srcのフォールバックが効かない為、個別指定が要る
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+  });
+
+  test('connect-srcはDataStackの3オリジンだけを追加で許可する', () => {
+    const [, parts] =
+      securityHeadersConfig().ContentSecurityPolicy.ContentSecurityPolicy['Fn::Join'];
+    // Cognito issuer、Hosted UI、ドキュメントバケットの3つ。
+    // スタック間参照になる為、ホスト名は文字列としてテンプレートに現れない
+    const references = parts.filter((part: unknown) => typeof part !== 'string');
+    expect(references).toHaveLength(3);
+
+    const [head] = parts;
+    expect(head).toContain("connect-src 'self' ");
+    // issuerの直後の'/'。CSPのパスは末尾がスラッシュのときだけ前方一致になり、
+    // 付けないと.well-known配下のディスカバリとJWKSが弾かれる
+    expect(parts[parts.indexOf(references[0]) + 1]).toMatch(/^\//);
+  });
+
+  test('HTTPSの強制と型推測の禁止、リファラの抑制を行う', () => {
+    const config = securityHeadersConfig();
+    expect(config.StrictTransportSecurity).toEqual({
+      AccessControlMaxAgeSec: 63072000,
+      IncludeSubdomains: true,
+      Override: true,
+    });
+    expect(config.ContentTypeOptions).toEqual({ Override: true });
+    expect(config.ReferrerPolicy.ReferrerPolicy).toBe(
+      'strict-origin-when-cross-origin',
+    );
   });
 });
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -447,7 +447,7 @@ CertificateStackだけは、ライフサイクルではなくリージョンを�
 
 #### appDomainによる循環参照の回避
 
-スタック間の依存は EdgeStack → AppStack → DataStack の一方向である。CloudFrontはAPI Gatewayを参照し、LambdaはDynamoDBやS3を参照する。
+スタック間の依存は EdgeStack → AppStack → DataStack の一方向である。CloudFrontはAPI Gatewayを参照し、LambdaはDynamoDBやS3を参照する。EdgeStackはDataStackも直接参照する。CSPの`connect-src`にCognitoとドキュメント用S3バケットのオリジンを載せるためであり([9.2](#92-cloudfront))、依存の向きは変わらない。
 
 一方、CognitoのコールバックURLとドキュメント保存用S3バケットのCORS許可オリジンには、SPAの公開ドメインが必要となる。このドメインを受けるのはCloudFrontであり、DataStackがEdgeStackを参照すると上記の依存と合わせて循環する。
 
@@ -485,6 +485,42 @@ SSEのストリーミングは、Lambda、Lambda Web Adapter、API Gateway、Clo
 ストリーム全体の上限は統合タイムアウトであり、CloudFrontの60秒はイベント間隔の上限として働く。KeepAliveはOriginとの接続を維持し、イベントごとの再接続を避ける。
 
 SPAはクライアントサイドルーティングを行うため、`/chats/{chatId}`のようなパスに対応するオブジェクトはS3に存在しない。拡張子を持たないリクエストのURIを`/index.html`へ書き換えるCloudFront Functionを、S3向けのビヘイビアにのみ適用する。CloudFrontのカスタムエラーレスポンスはディストリビューション全体へ適用され、APIが返すエラーレスポンスまで書き換えてしまうため利用しない。
+
+#### レスポンスヘッダー
+
+S3向けのビヘイビアに`ResponseHeadersPolicy`を適用し、セキュリティヘッダーを付与する。API向けのビヘイビアには適用しない。CSPが意味を持つのは、ブラウザがHTMLとして解釈するSPAの経路だけだからである。
+
+中心となるのはContent-Security-Policyである。アクセストークンをlocalStorageへ保存する判断([ADR-0010](./adr/0010-token-storage-localstorage.md))に対する緩和策であり、XSSが起きてもスクリプトの読み込みと外部への送信を成立させないことを狙う。
+
+```text
+default-src 'self';
+connect-src 'self' <Cognitoのissuer>/ <Hosted UIのドメイン> <ドキュメント用S3バケット>;
+object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+```
+
+SPAが同一オリジンの外へ発行する通信は次の3つに限られるため、`connect-src`ではこれらだけを追加で許可する。API呼び出しとチャットのSSEはいずれもCloudFront経由の同一オリジンであり、`'self'`で足りる。
+
+| 許可先 | 用途 |
+|------|------|
+| Cognitoのissuer | `oidc-client-ts`が読むディスカバリ文書とJWKS |
+| Hosted UIのドメイン | トークンエンドポイント。issuerとはホストが分かれる |
+| ドキュメント用S3バケット | 署名付きURLへの直接PUT([6.1](#61-アップロードフロー)) |
+
+ドキュメント用S3バケットについては、許可するホストとapi-fnが発行する署名付きURLのホストが一致していなければならない。boto3は既定でリージョンを含まないグローバルエンドポイントへ書き換え、非推奨のSigV2で署名するため、SigV4とvirtual-hosted styleを明示して発行する。
+
+一方、サインインの開始とサインアウトはHosted UIへの画面遷移であり、原本の閲覧も署名付きURLへの遷移であるため、いずれも`connect-src`の対象にはならない。
+
+issuerには末尾のスラッシュを付ける。CSPのパスは末尾がスラッシュのときだけ前方一致として扱われ、付けなければ完全一致の判定になって`/.well-known/`配下が弾かれる。ホストではなくUser Poolのパスまで指定することで、同一ホスト上にある他のUser Pool宛ての送信を防ぐ。
+
+Viteのビルド成果物は外部のJSモジュールとCSSだけで、インラインスクリプトもインラインスタイルも含まない。そのため`'unsafe-inline'`は指定しない。`object-src`、`base-uri`、`form-action`は`default-src`のフォールバックが働かないため個別に指定する。`X-Frame-Options`は`frame-ancestors`が置き換えるため設定しない。
+
+同じポリシーで次のヘッダーも配信する。
+
+| ヘッダー | 値 | 目的 |
+|------|------|------|
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains` | 以降のアクセスをHTTPSに固定する。preloadリストへの登録はapexドメイン単位となるため付けない |
+| `X-Content-Type-Options` | `nosniff` | Content-Typeを無視したMIMEスニッフィングを防ぐ |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | クロスオリジンへはオリジンのみを送り、パスやクエリを渡さない |
 
 ### 9.3 API Gateway
 


### PR DESCRIPTION
ADR-0010で対策として挙げていたContent Security Policyを実装し、
CloudFrontのレスポンスヘッダーとして配信する。

SPAのデフォルトビヘイビアにポリシーを適用し、`connect-src`で追加で
許可するのはCognitoのissuer、Hosted UI、ドキュメント用S3バケットの
3つだけとした。APIとチャットのSSEは同一オリジンのため`'self'`で足りる。
issuerには末尾のスラッシュを付けている。CSPのパスは末尾がスラッシュの
ときだけ前方一致として扱われ、付けなければdiscoveryとJWKSが弾かれる為。
この3つを実リソースから解決する為にEdgeStackがDataStackを参照するように
なるが、依存の向きは変わらない。CSPと併せてHSTS、
`X-Content-Type-Options`、`Referrer-Policy`も配信する。

また、SPAがブラウザから直接利用するS3の署名付きURLを修正した。boto3は
既定でリージョンを含まないグローバルエンドポイントへ書き換え、SigV2で
署名する為、CSPで許可した`bucketRegionalDomainName`とhostが食い違い、
デプロイ後のアップロードが実際に弾かれた。SigV4とvirtual-hosted styleを
明示し、発行先がCSPと一致することをテストで固定している。

EdgeStackは手動デプロイ済みで、レスポンスヘッダーとCognitoのdiscoveryが
想定どおりであることを確認済み。バックエンド変更反映後に、S3アップロードと
チャットのSSEを確認する。

fix(backend): presign S3 URLs with SigV4 and virtual-hosted style
feat(cdk): set security response headers on the SPA behavior
docs: document the CloudFront response headers

Closes #44
