### PR TITLE
Add Vitest tests to the frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      - run: npm test
       # VITE_COGNITO_*はビルド時に埋め込まれるが、型検査とバンドルは値なしでも通る。
       # 実際の値の注入はdeploy-frontend.ymlが行う
       - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ make install           # npm install (frontend) + uv sync (backend)
 make dev               # run frontend (:5173) and backend (:8000) dev servers together
 make lint              # eslint + prettier --check (frontend), ruff check + format --check (backend)
 make format            # prettier --write (frontend), ruff --fix + format (backend)
-make test              # backend pytest
+make test              # frontend vitest + backend pytest
 make docker-build      # build the api-fn image (web target)
 make docker-build-chat    # build the chat-fn image (chat target)
 make docker-build-worker  # build the ingest-fn image (worker target)
@@ -36,9 +36,18 @@ Day-to-day development is native (uv/npm). Docker exists only to build the produ
 ```bash
 npm run dev            # dev server on http://localhost:5173
 npm run build          # tsc -b && vite build
+npm test               # vitest run (test:watch for watch mode)
+npx vitest run test/lib/sse.test.ts        # single test file
+npx vitest run -t "コメント行を読み飛ばす"   # single test by name
 npm run lint           # eslint
 npm run format         # prettier --write (format:check for CI-style check)
 ```
+
+Frontend tests live in `apps/frontend/test/`, mirroring the `src/` layout, and
+run in jsdom with React Testing Library. Vitest globals are not injected — each
+test imports `describe` / `it` / `expect` / `vi` from `vitest`. The network
+boundary is faked with `vi.mock` and `fetch` stubs, not MSW. `tsconfig.test.json`
+is in `tsconfig.json`'s references, so `npm run build` type-checks the tests too.
 
 ### Backend (`apps/backend/`)
 
@@ -78,7 +87,7 @@ Target architecture (from `docs/architecture.md`; most of it is not yet implemen
 - **Data**: DynamoDB single-table design (e.g. `PK=USER#123`, `SK=CHAT#<ULID>`) for documents, chats, and messages. IDs are ULIDs; GSI1 (`GSI1PK=DOC|CHAT`, `GSI1SK=<id>`) serves both cross-user lists and ID-only lookups. S3 Vectors metadata: `documentId` (filterable), `text`/`filename` (non-filterable).
 - **Zero fixed cost is a hard constraint**: no VPC, no NAT, no ECS/EC2/Aurora, no Provisioned Concurrency.
 - **CDK is five stacks**: CertificateStack, DataStack, AppStack, EdgeStack, CiStack (see `cdk/README.md` for deploy prerequisites like the manual SSM SecureString setup and the ACM DNS validation done at the registrar). The SPA bucket lives in EdgeStack, not DataStack, because its OAC policy references the distribution. CertificateStack holds only the ACM certificate for the public domain and lives in us-east-1, the only region CloudFront can use; `appDomain` (default in `cdk.json`) carries the domain to DataStack without a stack reference. CiStack holds only the GitHub Actions OIDC provider and deploy role.
-- **CI/CD**: `.github/workflows/ci.yml` validates PRs (frontend lint/format/build, backend ruff/pytest, cdk typecheck/jest); `deploy-frontend.yml` and `deploy-backend.yml` deploy on merge to `main`. Workflows never run `cdk deploy` — infrastructure changes are applied manually. CDK snapshot tests normalize asset hashes via `cdk/test/helpers.ts`, so backend-only edits no longer break `npm test`.
+- **CI/CD**: `.github/workflows/ci.yml` validates PRs (frontend lint/format/vitest/build, backend ruff/pytest, cdk typecheck/jest); `deploy-frontend.yml` and `deploy-backend.yml` deploy on merge to `main`. Workflows never run `cdk deploy` — infrastructure changes are applied manually. CDK snapshot tests normalize asset hashes via `cdk/test/helpers.ts`, so backend-only edits no longer break `npm test`.
 - **Logging**: Lambda Powertools (structured logging, metrics, tracing); propagate the request ID across services.
 
 ## TypeScript Code Style

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ format:
 	cd apps/backend && uv run ruff check --fix . && uv run ruff format .
 
 test:
+	cd apps/frontend && npm test
 	cd apps/backend && uv run pytest
 
 docker-build: ## Build the api-fn (web target) image

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -1,73 +1,51 @@
-# React + TypeScript + Vite
+# frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Vite + React 19 SPA served from S3 via CloudFront. `/api/*` is routed to the
+backend by CloudFront in production, and by the Vite dev server proxy locally,
+so requests are same-origin in both (no CORS needed).
 
-Currently, two official plugins are available:
+## Setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Cognito settings are read from `.env.local` at build time; see `.env.example`.
 
-```js
-// eslint.config.js
-import reactX from "eslint-plugin-react-x";
-import reactDom from "eslint-plugin-react-dom";
+## Run dev server
 
-export default defineConfig([
-  globalIgnores(["dist"]),
-  {
-    files: ["**/*.{ts,tsx}"],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs["recommended-typescript"],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ["./tsconfig.node.json", "./tsconfig.app.json"],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-]);
+```bash
+npm run dev
+```
+
+Listens on http://localhost:5173 and proxies `/api` to http://localhost:8000,
+so the backend dev server has to be running too (`make dev` starts both).
+
+## Test
+
+```bash
+npm test                       # vitest run
+npm run test:watch             # watch mode
+npx vitest run test/lib/sse.test.ts          # single file
+npx vitest run -t "コメント行を読み飛ばす"    # single test by name
+```
+
+Tests live under `test/`, mirroring the `src/` layout. They run in jsdom with
+React Testing Library. Vitest globals are not injected — import `describe` /
+`it` / `expect` / `vi` from `vitest` in each file.
+
+## Build
+
+```bash
+npm run build
+```
+
+`tsc -b` type-checks `src/`, `vite.config.ts` and `test/` (one tsconfig each,
+wired through the references in `tsconfig.json`), then Vite bundles into `dist/`.
+
+## Lint / Format
+
+```bash
+npm run lint
+npm run format                 # format:check for a CI-style check
 ```

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -18,6 +18,10 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.4",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -26,10 +30,72 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
+        "jsdom": "^30.0.1",
         "prettier": "^3.9.5",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.62.0",
-        "vite": "^8.1.1"
+        "vite": "^8.1.1",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -224,6 +290,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -270,6 +346,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -432,6 +661,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -861,6 +1108,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
@@ -887,6 +1141,104 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -897,6 +1249,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -1218,6 +1595,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -1270,6 +1760,49 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1309,6 +1842,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1392,6 +1935,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1439,12 +1992,62 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1463,6 +2066,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1479,6 +2089,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1488,6 +2108,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1510,6 +2137,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1527,6 +2167,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -1753,6 +2400,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1761,6 +2418,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2054,6 +2721,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -2087,6 +2767,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2110,6 +2800,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2123,6 +2820,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2503,6 +3251,26 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2511,6 +3279,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2531,6 +3306,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2589,6 +3374,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/oidc-client-ts": {
@@ -2653,6 +3452,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2672,6 +3484,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2748,6 +3567,21 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -2787,6 +3621,13 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-oidc-context": {
       "version": "3.3.1",
@@ -2839,6 +3680,30 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -2871,6 +3736,19 @@
         "@rolldown/binding-wasm32-wasi": "1.1.5",
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -2918,6 +3796,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2926,6 +3811,57 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2943,6 +3879,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3015,6 +4007,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -3143,6 +4145,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3159,6 +4299,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3168,6 +4325,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -22,6 +24,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.4",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -30,9 +36,11 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
+    "jsdom": "^30.0.1",
     "prettier": "^3.9.5",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.62.0",
-    "vite": "^8.1.1"
+    "vite": "^8.1.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/frontend/test/api/chats.test.ts
+++ b/apps/frontend/test/api/chats.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { streamChat } from "../../src/api/chats";
+import type { ChatStreamEvent } from "../../src/api/chats";
+import { streamOf } from "../helpers/stream";
+
+// userManagerはimport時に実物のUserManagerを構築し、window.localStorageとVITE_COGNITO_*を触る
+const getUser = vi.fn();
+vi.mock("../../src/auth/userManager", () => ({
+  userManager: { getUser: () => getUser() },
+}));
+
+const INTERRUPTED_MESSAGE =
+  "回答の生成が中断されました。もう一度お試しください。";
+
+function stubFetch(response: Response | Error) {
+  const fetchMock = vi.fn<typeof fetch>(() => {
+    if (response instanceof Error) return Promise.reject(response);
+    return Promise.resolve(response);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function sseResponse(...chunks: string[]): Response {
+  return new Response(streamOf(...chunks), { status: 200 });
+}
+
+function collector() {
+  const events: ChatStreamEvent[] = [];
+  return { events, onEvent: (event: ChatStreamEvent) => events.push(event) };
+}
+
+beforeEach(() => {
+  getUser.mockResolvedValue({ access_token: "token-abc" });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("streamChat", () => {
+  it("updateとdoneを届いた順にonEventへ渡し、doneで終了する", async () => {
+    stubFetch(
+      sseResponse(
+        'event: update\ndata: {"node":"generate_queries_node","state":{"retry_count":0}}\n\n',
+        'event: done\ndata: {"chatId":"chat-1","finalGrade":"useful","retryCount":0}\n\n',
+      ),
+    );
+    const { events, onEvent } = collector();
+
+    await streamChat("質問", onEvent, new AbortController().signal);
+
+    expect(events).toEqual([
+      {
+        type: "update",
+        node: "generate_queries_node",
+        state: { retry_count: 0 },
+      },
+      {
+        type: "done",
+        chatId: "chat-1",
+        finalGrade: "useful",
+        retryCount: 0,
+      },
+    ]);
+  });
+
+  it("doneより後のイベントは読まない", async () => {
+    stubFetch(
+      sseResponse(
+        'event: done\ndata: {"chatId":"chat-1","finalGrade":null,"retryCount":0}\n\n',
+        'event: update\ndata: {"node":"generate_answer_node","state":{}}\n\n',
+      ),
+    );
+    const { events, onEvent } = collector();
+
+    await streamChat("質問", onEvent, new AbortController().signal);
+
+    expect(events).toHaveLength(1);
+  });
+
+  it("アクセストークンがあればAuthorizationヘッダーを付ける", async () => {
+    const fetchMock = stubFetch(
+      sseResponse(
+        'event: done\ndata: {"chatId":"c","finalGrade":null,"retryCount":0}\n\n',
+      ),
+    );
+    const signal = new AbortController().signal;
+
+    await streamChat("質問", collector().onEvent, signal);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/chats/stream", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        Authorization: "Bearer token-abc",
+      },
+      body: JSON.stringify({ question: "質問" }),
+      signal,
+    });
+  });
+
+  it("サインインしていなければAuthorizationヘッダーを付けない", async () => {
+    getUser.mockResolvedValue(null);
+    const fetchMock = stubFetch(
+      sseResponse(
+        'event: done\ndata: {"chatId":"c","finalGrade":null,"retryCount":0}\n\n',
+      ),
+    );
+
+    await streamChat("質問", collector().onEvent, new AbortController().signal);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.headers).not.toHaveProperty("Authorization");
+  });
+
+  it("errorイベントでリクエストID付きのエラーをthrowする", async () => {
+    stubFetch(
+      sseResponse(
+        'event: error\ndata: {"message":"生成に失敗しました","requestId":"req-1"}\n\n',
+      ),
+    );
+
+    await expect(
+      streamChat("質問", collector().onEvent, new AbortController().signal),
+    ).rejects.toThrow("生成に失敗しました（リクエストID: req-1）");
+  });
+
+  it("401と403のレスポンスで認証切れの案内をthrowする", async () => {
+    for (const status of [401, 403]) {
+      stubFetch(new Response("", { status }));
+
+      await expect(
+        streamChat("質問", collector().onEvent, new AbortController().signal),
+      ).rejects.toThrow(
+        "認証の有効期限が切れた可能性があります。ページを再読み込みしてください。",
+      );
+    }
+  });
+
+  it("エラーレスポンスのdetailをメッセージへ含める", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ detail: "質問が長すぎます" }), {
+        status: 422,
+      }),
+    );
+
+    await expect(
+      streamChat("質問", collector().onEvent, new AbortController().signal),
+    ).rejects.toThrow("回答の生成に失敗しました（質問が長すぎます）");
+  });
+
+  it("detailのないエラーレスポンスはステータスを添える", async () => {
+    stubFetch(new Response("Internal Server Error", { status: 500 }));
+
+    await expect(
+      streamChat("質問", collector().onEvent, new AbortController().signal),
+    ).rejects.toThrow("回答の生成に失敗しました（HTTP 500）");
+  });
+
+  it("doneが届かないままbodyが閉じたら中断のエラーをthrowする", async () => {
+    stubFetch(
+      sseResponse(
+        'event: update\ndata: {"node":"generate_answer_node","state":{}}\n\n',
+      ),
+    );
+
+    await expect(
+      streamChat("質問", collector().onEvent, new AbortController().signal),
+    ).rejects.toThrow(INTERRUPTED_MESSAGE);
+  });
+
+  it("bodyのないレスポンスも中断として扱う", async () => {
+    stubFetch(new Response(null, { status: 200 }));
+
+    await expect(
+      streamChat("質問", collector().onEvent, new AbortController().signal),
+    ).rejects.toThrow(INTERRUPTED_MESSAGE);
+  });
+
+  it("AbortErrorはそのまま投げ直す", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    stubFetch(abortError);
+
+    await expect(
+      streamChat("質問", collector().onEvent, new AbortController().signal),
+    ).rejects.toBe(abortError);
+  });
+
+  it("通信エラーは接続失敗の案内へ包み、原因を残す", async () => {
+    const cause = new TypeError("Failed to fetch");
+    stubFetch(cause);
+
+    const promise = streamChat(
+      "質問",
+      collector().onEvent,
+      new AbortController().signal,
+    );
+
+    await expect(promise).rejects.toThrow(
+      "回答の生成に失敗しました（サーバーに接続できませんでした）",
+    );
+    await expect(promise).rejects.toHaveProperty("cause", cause);
+  });
+
+  it("未知のイベント名を読み飛ばす", async () => {
+    stubFetch(
+      sseResponse(
+        "event: ping\ndata: {}\n\n",
+        'event: done\ndata: {"chatId":"c","finalGrade":null,"retryCount":0}\n\n',
+      ),
+    );
+    const { events, onEvent } = collector();
+
+    await streamChat("質問", onEvent, new AbortController().signal);
+
+    expect(events).toEqual([
+      { type: "done", chatId: "c", finalGrade: null, retryCount: 0 },
+    ]);
+  });
+});

--- a/apps/frontend/test/api/client.test.ts
+++ b/apps/frontend/test/api/client.test.ts
@@ -1,0 +1,61 @@
+import type { InternalAxiosRequestConfig } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../src/api/client";
+
+const getUser = vi.fn();
+vi.mock("../../src/auth/userManager", () => ({
+  userManager: { getUser: () => getUser() },
+}));
+
+/** インターセプタは戻り値の関数ではない為、送信直前のconfigをアダプタで捕まえる。 */
+function captureRequestConfig() {
+  let captured: InternalAxiosRequestConfig | undefined;
+  api.defaults.adapter = (config) => {
+    captured = config;
+    return Promise.resolve({
+      data: {},
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    });
+  };
+  return () => captured;
+}
+
+beforeEach(() => {
+  getUser.mockReset();
+});
+
+afterEach(() => {
+  delete api.defaults.adapter;
+});
+
+describe("apiのリクエストインターセプタ", () => {
+  it("アクセストークンをAuthorizationヘッダーへ載せる", async () => {
+    getUser.mockResolvedValue({ access_token: "token-abc" });
+    const config = captureRequestConfig();
+
+    await api.get("/documents");
+
+    expect(config()?.headers.Authorization).toBe("Bearer token-abc");
+  });
+
+  it("サインインしていなければヘッダーを付けない", async () => {
+    getUser.mockResolvedValue(null);
+    const config = captureRequestConfig();
+
+    await api.get("/documents");
+
+    expect(config()?.headers.Authorization).toBeUndefined();
+  });
+
+  it("baseURLに/apiを使う", async () => {
+    getUser.mockResolvedValue(null);
+    const config = captureRequestConfig();
+
+    await api.get("/documents");
+
+    expect(config()?.baseURL).toBe("/api");
+  });
+});

--- a/apps/frontend/test/api/documents.test.ts
+++ b/apps/frontend/test/api/documents.test.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { putToS3 } from "../../src/api/documents";
+
+vi.mock("../../src/auth/userManager", () => ({
+  userManager: { getUser: () => Promise.resolve(null) },
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("putToS3", () => {
+  it("素のaxiosで送り、Authorizationヘッダーを付けない", async () => {
+    // apiインスタンス経由だと署名付きURLへ認証ヘッダーが二重に付き、S3が400を返す
+    const put = vi.spyOn(axios, "put").mockResolvedValue({ status: 200 });
+    const file = new File(["本文"], "manual.pdf", { type: "application/pdf" });
+
+    await putToS3("https://example.com/signed", file, "application/pdf");
+
+    expect(put).toHaveBeenCalledWith("https://example.com/signed", file, {
+      headers: { "Content-Type": "application/pdf" },
+    });
+    const [, , config] = put.mock.calls[0];
+    expect(config?.headers).not.toHaveProperty("Authorization");
+  });
+
+  it("署名発行時と同じContent-Typeをそのまま送る", async () => {
+    const put = vi.spyOn(axios, "put").mockResolvedValue({ status: 200 });
+    const file = new File(["# 見出し"], "readme.md", { type: "" });
+
+    await putToS3(
+      "https://example.com/signed",
+      file,
+      "text/plain; charset=utf-8",
+    );
+
+    const [, , config] = put.mock.calls[0];
+    expect(config?.headers).toEqual({
+      "Content-Type": "text/plain; charset=utf-8",
+    });
+  });
+});

--- a/apps/frontend/test/components/ChatProgress.test.tsx
+++ b/apps/frontend/test/components/ChatProgress.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { RetrievedDocument } from "../../src/api/chats";
+import { ChatProgress } from "../../src/components/ChatProgress";
+import type { Attempt } from "../../src/lib/chatProgress";
+
+function retrieved(
+  overrides: Partial<RetrievedDocument> = {},
+): RetrievedDocument {
+  return {
+    documentId: "doc-1",
+    filename: "manual.pdf",
+    text: "本文",
+    score: 0.825,
+    ...overrides,
+  };
+}
+
+/** 実行中として描画されているステップのラベル。 */
+function runningLabels(container: HTMLElement): string[] {
+  return [...container.querySelectorAll(".step-running .step-label")].map(
+    (label) => label.textContent ?? "",
+  );
+}
+
+describe("ChatProgress", () => {
+  it("ストリーミング中は最後の試行の未完了ステップの先頭だけを実行中にする", () => {
+    // SSEはノードの完了時にしか届かない為、回答生成は「走っているはず」の状態
+    const attempts: Attempt[] = [
+      { queries: ["q1"], documents: [retrieved()], answer: "1回目" },
+      { queries: ["q2"], documents: [retrieved()] },
+    ];
+
+    const { container } = render(
+      <ChatProgress attempts={attempts} isStreaming />,
+    );
+
+    expect(runningLabels(container)).toEqual(["Generation"]);
+  });
+
+  it("ストリーミングが終われば実行中のステップはなくなる", () => {
+    const attempts: Attempt[] = [{ queries: ["q1"], documents: [retrieved()] }];
+
+    const { container } = render(
+      <ChatProgress attempts={attempts} isStreaming={false} />,
+    );
+
+    expect(runningLabels(container)).toEqual([]);
+  });
+
+  it("showAnswerBodyで回答の文字数表示と本文表示が切り替わる", () => {
+    const attempts: Attempt[] = [{ answer: "12345" }];
+
+    const { rerender } = render(
+      <ChatProgress attempts={attempts} isStreaming={false} />,
+    );
+    expect(screen.getByText("回答を生成しました（5文字）")).toBeInTheDocument();
+
+    rerender(
+      <ChatProgress attempts={attempts} isStreaming={false} showAnswerBody />,
+    );
+    expect(screen.getByText("12345")).toBeInTheDocument();
+    expect(screen.queryByText(/文字）/)).not.toBeInTheDocument();
+  });
+
+  it("documentIdのない断片は原本を開くボタンにしない", () => {
+    const attempts: Attempt[] = [
+      {
+        documents: [
+          retrieved({ filename: "traceable.pdf" }),
+          retrieved({ documentId: null, filename: "orphan.pdf" }),
+        ],
+      },
+    ];
+
+    render(
+      <ChatProgress
+        attempts={attempts}
+        isStreaming={false}
+        onOpenDocument={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "traceable.pdf" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "orphan.pdf" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("orphan.pdf")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/test/components/DocumentTable.test.tsx
+++ b/apps/frontend/test/components/DocumentTable.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { DocumentStatus, DocumentSummary } from "../../src/api/documents";
+import { DocumentTable } from "../../src/components/DocumentTable";
+
+const CURRENT_USER = "user-me";
+
+function document(
+  overrides: Partial<DocumentSummary> & { documentId: string },
+): DocumentSummary {
+  return {
+    userId: CURRENT_USER,
+    filename: `${overrides.documentId}.pdf`,
+    status: "uploaded",
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderTable(props: Partial<Parameters<typeof DocumentTable>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <DocumentTable
+        documents={props.documents ?? []}
+        currentUserId={CURRENT_USER}
+        onOpen={vi.fn()}
+        openingId={null}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
+function ingestButtonsByRow(): (HTMLElement | null)[] {
+  return screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => within(row).queryByRole("button", { name: "取込開始" }));
+}
+
+describe("DocumentTable", () => {
+  it("取込開始ボタンは自分のドキュメントかつuploaded / failedのときだけ表示する", () => {
+    const statuses: DocumentStatus[] = [
+      "uploading",
+      "uploaded",
+      "processing",
+      "ingested",
+      "failed",
+    ];
+    const documents = statuses.map((status) =>
+      document({ documentId: status, status }),
+    );
+    documents.push(
+      document({
+        documentId: "others",
+        userId: "user-other",
+        status: "uploaded",
+      }),
+    );
+
+    renderTable({ documents, onIngest: vi.fn() });
+
+    expect(ingestButtonsByRow().map(Boolean)).toEqual([
+      false, // uploading
+      true, // uploaded
+      false, // processing
+      false, // ingested
+      true, // failed
+      false, // 他人のuploaded
+    ]);
+  });
+
+  it("onIngestを渡さない場合は取込開始ボタンを表示しない", () => {
+    renderTable({
+      documents: [document({ documentId: "doc-1", status: "uploaded" })],
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "取込開始" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("showOwnerのとき自分の行を「自分」、他人の行を「ユーザー」と表示する", () => {
+    renderTable({
+      documents: [
+        document({ documentId: "mine" }),
+        document({ documentId: "theirs", userId: "user-other" }),
+      ],
+      showOwner: true,
+    });
+
+    const [mine, theirs] = screen.getAllByRole("row").slice(1);
+    expect(within(mine).getByRole("link")).toHaveTextContent("自分");
+    expect(within(theirs).getByRole("link")).toHaveTextContent("ユーザー");
+    expect(within(theirs).getByRole("link")).toHaveAttribute(
+      "href",
+      "/user/user-other",
+    );
+  });
+});

--- a/apps/frontend/test/components/UploadForm.test.tsx
+++ b/apps/frontend/test/components/UploadForm.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { UploadForm } from "../../src/components/UploadForm";
+
+function pdf(name = "manual.pdf") {
+  return new File(["本文"], name, { type: "application/pdf" });
+}
+
+function fileInput(): HTMLInputElement {
+  return screen.getByLabelText(/ファイルを選択/) as HTMLInputElement;
+}
+
+describe("UploadForm", () => {
+  it("選択したファイルをそのままonUploadへ渡す", async () => {
+    const onUpload = vi.fn().mockResolvedValue(true);
+    render(<UploadForm onUpload={onUpload} isUploading={false} />);
+    const file = pdf();
+
+    await userEvent.upload(fileInput(), file);
+    await userEvent.click(screen.getByRole("button", { name: "アップロード" }));
+
+    expect(onUpload).toHaveBeenCalledWith(file);
+  });
+
+  it("アップロード成功で選択状態がクリアされる", async () => {
+    const onUpload = vi.fn().mockResolvedValue(true);
+    render(<UploadForm onUpload={onUpload} isUploading={false} />);
+
+    await userEvent.upload(fileInput(), pdf());
+    expect(screen.getByText("manual.pdf")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "アップロード" }));
+
+    expect(
+      screen.getByText("ファイルが選択されていません"),
+    ).toBeInTheDocument();
+    expect(fileInput().value).toBe("");
+  });
+
+  it("アップロード失敗では選択状態が残る", async () => {
+    const onUpload = vi.fn().mockResolvedValue(false);
+    render(<UploadForm onUpload={onUpload} isUploading={false} />);
+
+    await userEvent.upload(fileInput(), pdf());
+    await userEvent.click(screen.getByRole("button", { name: "アップロード" }));
+
+    // やり直せるよう選択は残す
+    expect(screen.getByText("manual.pdf")).toBeInTheDocument();
+    expect(fileInput().files).toHaveLength(1);
+  });
+});

--- a/apps/frontend/test/helpers/stream.ts
+++ b/apps/frontend/test/helpers/stream.ts
@@ -1,0 +1,23 @@
+const encoder = new TextEncoder();
+
+/** チャンクの区切りをそのまま再現するReadableStreamを作る。 */
+export function streamOf(
+  ...chunks: (string | Uint8Array)[]
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          typeof chunk === "string" ? encoder.encode(chunk) : chunk,
+        );
+      }
+      controller.close();
+    },
+  });
+}
+
+/** UTF-8のバイト列を指定位置で分割する。マルチバイト文字の途中で切る為に使う。 */
+export function splitBytes(text: string, at: number): [Uint8Array, Uint8Array] {
+  const bytes = encoder.encode(text);
+  return [bytes.slice(0, at), bytes.slice(at)];
+}

--- a/apps/frontend/test/lib/chatProgress.test.ts
+++ b/apps/frontend/test/lib/chatProgress.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { ChatAttempt, RetrievedDocument } from "../../src/api/chats";
+import { applyUpdate, toAttempt } from "../../src/lib/chatProgress";
+import type { Attempt } from "../../src/lib/chatProgress";
+
+const DOCUMENT: RetrievedDocument = {
+  documentId: "doc-1",
+  filename: "manual.pdf",
+  text: "本文",
+  score: 0.8,
+};
+
+describe("applyUpdate", () => {
+  it("generate_queries_nodeの到着で新しい試行が始まる", () => {
+    const attempts = applyUpdate([], {
+      node: "generate_queries_node",
+      state: { retry_count: 0, queries: ["q1", "q2"] },
+    });
+
+    expect(attempts).toEqual([{ queries: ["q1", "q2"] }]);
+  });
+
+  it("リトライではretry_countより後ろの試行を破棄して作り直す", () => {
+    // retry_countは試行の添字なので、それより後ろに積んだ分はすべて捨てる
+    const attempts: Attempt[] = [
+      { queries: ["q1"], answer: "1回目" },
+      { queries: ["q2"], answer: "2回目" },
+      { queries: ["q3"], answer: "3回目" },
+    ];
+
+    const next = applyUpdate(attempts, {
+      node: "generate_queries_node",
+      state: { retry_count: 1, queries: ["q2-new"] },
+    });
+
+    expect(next).toHaveLength(2);
+    expect(next[0]).toEqual({ queries: ["q1"], answer: "1回目" });
+    // 作り直した試行はqueriesだけを持ち、前回の回答は残らない
+    expect(next[1]).toEqual({ queries: ["q2-new"] });
+  });
+
+  it("先頭ノードより先に他のノードが届いた場合は何も変えない", () => {
+    const attempts: Attempt[] = [];
+
+    const next = applyUpdate(attempts, {
+      node: "generate_answer_node",
+      state: { answer: "回答" },
+    });
+
+    expect(next).toBe(attempts);
+  });
+
+  it("各ノードの更新を最後の試行へマージする", () => {
+    let attempts = applyUpdate([], {
+      node: "generate_queries_node",
+      state: { retry_count: 0, queries: ["q1"] },
+    });
+    attempts = applyUpdate(attempts, {
+      node: "retrieve_contexts_node",
+      state: { documents: [DOCUMENT] },
+    });
+    attempts = applyUpdate(attempts, {
+      node: "generate_answer_node",
+      state: { answer: "回答" },
+    });
+    attempts = applyUpdate(attempts, {
+      node: "grade_answer_node",
+      state: { grade: "useless", feedback: "根拠が不足しています" },
+    });
+    attempts = applyUpdate(attempts, {
+      node: "analyze_failure_node",
+      state: { failure_analysis: "検索クエリが広すぎます" },
+    });
+
+    expect(attempts).toEqual([
+      {
+        queries: ["q1"],
+        documents: [DOCUMENT],
+        answer: "回答",
+        grade: "useless",
+        feedback: "根拠が不足しています",
+        failureAnalysis: "検索クエリが広すぎます",
+      },
+    ]);
+  });
+
+  it("検索結果が届かない場合は空配列を入れて完了扱いにする", () => {
+    const attempts = applyUpdate([{ queries: ["q1"] }], {
+      node: "retrieve_contexts_node",
+      state: {},
+    });
+
+    expect(attempts[0].documents).toEqual([]);
+  });
+
+  it("元の配列を書き換えない", () => {
+    const attempts: Attempt[] = [{ queries: ["q1"] }];
+
+    applyUpdate(attempts, {
+      node: "generate_answer_node",
+      state: { answer: "回答" },
+    });
+
+    expect(attempts).toEqual([{ queries: ["q1"] }]);
+  });
+});
+
+describe("toAttempt", () => {
+  it("RESTのnullをundefinedへ落とす", () => {
+    const stored: ChatAttempt = {
+      attemptNo: 1,
+      queries: ["q1"],
+      documents: [DOCUMENT],
+      answer: null,
+      grade: null,
+      feedback: null,
+      failureAnalysis: null,
+    };
+
+    expect(toAttempt(stored)).toEqual({
+      queries: ["q1"],
+      documents: [DOCUMENT],
+      answer: undefined,
+      grade: undefined,
+      feedback: undefined,
+      failureAnalysis: undefined,
+    });
+  });
+
+  it("空文字の回答はundefinedへ落とさない", () => {
+    const stored: ChatAttempt = {
+      attemptNo: 1,
+      queries: [],
+      documents: [],
+      answer: "",
+      grade: "useful",
+      feedback: null,
+      failureAnalysis: null,
+    };
+
+    expect(toAttempt(stored).answer).toBe("");
+  });
+});

--- a/apps/frontend/test/lib/errors.test.ts
+++ b/apps/frontend/test/lib/errors.test.ts
@@ -1,0 +1,104 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import type { AxiosResponse } from "axios";
+import { describe, expect, it } from "vitest";
+import {
+  isNotFound,
+  toAuthErrorMessage,
+  toErrorMessage,
+} from "../../src/lib/errors";
+
+const AUTH_MESSAGE =
+  "認証の有効期限が切れた可能性があります。ページを再読み込みしてください。";
+
+function axiosErrorWith(status: number, data?: unknown): AxiosError {
+  const config = { headers: new AxiosHeaders() };
+  const response = { status, data, config } as AxiosResponse;
+  return new AxiosError(
+    "request failed",
+    "ERR_BAD_RESPONSE",
+    config,
+    {},
+    response,
+  );
+}
+
+/** レスポンスの届かない通信エラー。axiosはresponseなしのAxiosErrorを投げる */
+function networkError(): AxiosError {
+  return new AxiosError("Network Error", AxiosError.ERR_NETWORK);
+}
+
+describe("toAuthErrorMessage", () => {
+  it("401と403で認証切れの案内を返す", () => {
+    expect(toAuthErrorMessage(401)).toBe(AUTH_MESSAGE);
+    expect(toAuthErrorMessage(403)).toBe(AUTH_MESSAGE);
+  });
+
+  it("それ以外のステータスとundefinedはnullを返す", () => {
+    expect(toAuthErrorMessage(404)).toBeNull();
+    expect(toAuthErrorMessage(500)).toBeNull();
+    expect(toAuthErrorMessage(undefined)).toBeNull();
+  });
+});
+
+describe("isNotFound", () => {
+  it("404のAxiosErrorだけを真とする", () => {
+    expect(isNotFound(axiosErrorWith(404))).toBe(true);
+    expect(isNotFound(axiosErrorWith(409))).toBe(false);
+    expect(isNotFound(networkError())).toBe(false);
+    expect(isNotFound(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("toErrorMessage", () => {
+  it("401と403は認証切れの案内へ差し替える", () => {
+    expect(toErrorMessage(axiosErrorWith(401), "取得に失敗しました")).toBe(
+      AUTH_MESSAGE,
+    );
+    expect(toErrorMessage(axiosErrorWith(403), "取得に失敗しました")).toBe(
+      AUTH_MESSAGE,
+    );
+  });
+
+  it("404と409はそれぞれの案内を返す", () => {
+    expect(toErrorMessage(axiosErrorWith(404), "取得に失敗しました")).toBe(
+      "対象のドキュメントが見つかりません。一覧を再取得してください。",
+    );
+    expect(toErrorMessage(axiosErrorWith(409), "取得に失敗しました")).toBe(
+      "ドキュメントの状態が変わっています。一覧を再取得しました。",
+    );
+  });
+
+  it("レスポンスがない場合は接続失敗の補足を添える", () => {
+    expect(toErrorMessage(networkError(), "取得に失敗しました")).toBe(
+      "取得に失敗しました（サーバーに接続できませんでした）",
+    );
+  });
+
+  it("detailがあればフォールバック文言へ添える", () => {
+    const error = axiosErrorWith(400, { detail: "ファイル形式が不正です" });
+    expect(toErrorMessage(error, "取得に失敗しました")).toBe(
+      "取得に失敗しました（ファイル形式が不正です）",
+    );
+  });
+
+  it("detailが文字列でない場合はフォールバック文言のみ返す", () => {
+    expect(toErrorMessage(axiosErrorWith(500, {}), "取得に失敗しました")).toBe(
+      "取得に失敗しました",
+    );
+    expect(
+      toErrorMessage(
+        axiosErrorWith(500, { detail: { code: 1 } }),
+        "取得に失敗しました",
+      ),
+    ).toBe("取得に失敗しました");
+  });
+
+  it("axios以外のエラーはフォールバック文言をそのまま返す", () => {
+    expect(toErrorMessage(new Error("boom"), "取得に失敗しました")).toBe(
+      "取得に失敗しました",
+    );
+    expect(toErrorMessage("boom", "取得に失敗しました")).toBe(
+      "取得に失敗しました",
+    );
+  });
+});

--- a/apps/frontend/test/lib/fileTypes.test.ts
+++ b/apps/frontend/test/lib/fileTypes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { contentTypeFor } from "../../src/lib/fileTypes";
+
+describe("contentTypeFor", () => {
+  it("署名に使うContent-Typeを拡張子から決める", () => {
+    expect(contentTypeFor("manual.pdf")).toBe("application/pdf");
+    expect(contentTypeFor("readme.md")).toBe("text/plain; charset=utf-8");
+  });
+
+  it("拡張子の大文字小文字を区別しない", () => {
+    expect(contentTypeFor("MANUAL.PDF")).toBe("application/pdf");
+    expect(contentTypeFor("Readme.Md")).toBe("text/plain; charset=utf-8");
+  });
+
+  it("非対応の拡張子と拡張子なしはnullを返す", () => {
+    expect(contentTypeFor("archive.zip")).toBeNull();
+    expect(contentTypeFor("archive.tar.gz")).toBeNull();
+    expect(contentTypeFor("README")).toBeNull();
+    expect(contentTypeFor("trailing.")).toBeNull();
+  });
+});

--- a/apps/frontend/test/lib/sse.test.ts
+++ b/apps/frontend/test/lib/sse.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { readSse } from "../../src/lib/sse";
+import type { SseEvent } from "../../src/lib/sse";
+import { splitBytes, streamOf } from "../helpers/stream";
+
+async function collect(body: ReadableStream<Uint8Array>): Promise<SseEvent[]> {
+  const events: SseEvent[] = [];
+  for await (const event of readSse(body)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("readSse", () => {
+  it("イベントがチャンク境界で分割されても復元する", async () => {
+    const events = await collect(
+      streamOf("event: upd", "ate\ndata: {", '"node":"a"}\n\n'),
+    );
+
+    expect(events).toEqual([{ event: "update", data: '{"node":"a"}' }]);
+  });
+
+  it("1チャンクに複数のイベントが入っていても分割する", async () => {
+    const events = await collect(
+      streamOf("event: update\ndata: 1\n\nevent: done\ndata: 2\n\n"),
+    );
+
+    expect(events).toEqual([
+      { event: "update", data: "1" },
+      { event: "done", data: "2" },
+    ]);
+  });
+
+  it("マルチバイト文字がチャンク境界で分割されても壊れない", async () => {
+    // 「あ」はUTF-8で3バイト。その2バイト目で切る
+    const [head, tail] = splitBytes("data: あいうえお\n\n", 7);
+
+    const events = await collect(streamOf(head, tail));
+
+    expect(events).toEqual([{ event: "message", data: "あいうえお" }]);
+  });
+
+  it("コメント行を読み飛ばす", async () => {
+    // KeepAliveはコメント行で送られる
+    const events = await collect(
+      streamOf(": keep-alive\n\n", "event: done\ndata: 1\n\n"),
+    );
+
+    expect(events).toEqual([{ event: "done", data: "1" }]);
+  });
+
+  it("event行がないブロックはmessageとして扱う", async () => {
+    const events = await collect(streamOf("data: 1\n\n"));
+
+    expect(events).toEqual([{ event: "message", data: "1" }]);
+  });
+
+  it("複数のdata行を改行で連結する", async () => {
+    const events = await collect(
+      streamOf("event: update\ndata: 1\ndata: 2\n\n"),
+    );
+
+    expect(events).toEqual([{ event: "update", data: "1\n2" }]);
+  });
+
+  it("data行のないブロックはイベントとして返さない", async () => {
+    const events = await collect(streamOf("event: update\n\n", "data: 1\n\n"));
+
+    expect(events).toEqual([{ event: "message", data: "1" }]);
+  });
+
+  it("空行で終わらないまま閉じた末尾の不完全なブロックを捨てる", async () => {
+    const events = await collect(
+      streamOf("event: update\ndata: 1\n\n", "event: done\ndata: 2"),
+    );
+
+    expect(events).toEqual([{ event: "update", data: "1" }]);
+  });
+
+  it("値の先頭の空白を1つだけ取り除く", async () => {
+    const events = await collect(streamOf("data:  leading\n\n"));
+
+    expect(events).toEqual([{ event: "message", data: " leading" }]);
+  });
+
+  it("最初のコロン以降をすべて値として扱う", async () => {
+    const events = await collect(streamOf('data: {"a": 1}\n\n'));
+
+    expect(events).toEqual([{ event: "message", data: '{"a": 1}' }]);
+  });
+
+  it("途中で読むのをやめたらstreamをキャンセルする", async () => {
+    const body = streamOf("data: 1\n\n", "data: 2\n\n");
+    const events = readSse(body);
+
+    await events.next();
+    await events.return(undefined);
+
+    // readerを握ったままなら再取得は失敗する
+    expect(body.locked).toBe(true);
+    await expect(collect(body)).rejects.toThrow();
+  });
+});

--- a/apps/frontend/test/lib/useOpenDocument.test.ts
+++ b/apps/frontend/test/lib/useOpenDocument.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from "@testing-library/react";
+import { AxiosError, AxiosHeaders } from "axios";
+import type { AxiosResponse } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useOpenDocument } from "../../src/lib/useOpenDocument";
+
+const fetchDownloadUrl = vi.fn();
+vi.mock("../../src/api/documents", () => ({
+  fetchDownloadUrl: (documentId: string) => fetchDownloadUrl(documentId),
+}));
+
+interface FakeTab {
+  opener: unknown;
+  location: { href: string };
+  close: ReturnType<typeof vi.fn>;
+}
+
+function fakeTab(): FakeTab {
+  return { opener: {}, location: { href: "" }, close: vi.fn() };
+}
+
+/** jsdomのwindow.openはnullを返し、location代入も未実装の為、差し替える。 */
+function stubWindowOpen(tab: FakeTab | null) {
+  const open = vi.fn(() => tab);
+  vi.stubGlobal("open", open);
+  return open;
+}
+
+beforeEach(() => {
+  fetchDownloadUrl.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useOpenDocument", () => {
+  it("空タブを先に開き、URL取得後に遷移させる", async () => {
+    const tab = fakeTab();
+    const open = stubWindowOpen(tab);
+    let resolveUrl: (value: { downloadUrl: string }) => void = () => {};
+    fetchDownloadUrl.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUrl = resolve;
+      }),
+    );
+    const { result } = renderHook(() => useOpenDocument(vi.fn()));
+
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.openDocument("doc-1");
+    });
+
+    // ポップアップブロックを避ける為、URL取得を待たずにタブを開く
+    expect(open).toHaveBeenCalledWith("", "_blank");
+    expect(tab.opener).toBeNull();
+    expect(result.current.openingId).toBe("doc-1");
+
+    await act(async () => {
+      resolveUrl({ downloadUrl: "https://example.com/signed" });
+      await pending;
+    });
+
+    expect(tab.location.href).toBe("https://example.com/signed");
+    expect(result.current.openingId).toBeNull();
+  });
+
+  it("URL取得に失敗したらタブを閉じ、エラーメッセージを呼び出し側へ渡す", async () => {
+    const tab = fakeTab();
+    stubWindowOpen(tab);
+    const config = { headers: new AxiosHeaders() };
+    fetchDownloadUrl.mockRejectedValue(
+      new AxiosError("not found", "ERR_BAD_REQUEST", config, {}, {
+        status: 404,
+        data: {},
+        config,
+      } as AxiosResponse),
+    );
+    const onError = vi.fn();
+    const { result } = renderHook(() => useOpenDocument(onError));
+
+    await act(async () => {
+      await result.current.openDocument("doc-1");
+    });
+
+    expect(tab.close).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      "対象のドキュメントが見つかりません。一覧を再取得してください。",
+    );
+    expect(result.current.openingId).toBeNull();
+  });
+
+  it("window.openがnullを返した場合にポップアップ設定の案内を渡す", async () => {
+    stubWindowOpen(null);
+    fetchDownloadUrl.mockResolvedValue({
+      downloadUrl: "https://example.com/signed",
+    });
+    const onError = vi.fn();
+    const { result } = renderHook(() => useOpenDocument(onError));
+
+    await act(async () => {
+      await result.current.openDocument("doc-1");
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      "別タブを開けませんでした。ブラウザのポップアップ設定を確認してください",
+    );
+  });
+});

--- a/apps/frontend/test/setup.ts
+++ b/apps/frontend/test/setup.ts
@@ -1,0 +1,6 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// globalsを注入しない設定では、RTLの自動cleanupが働かない為ここで登録する
+afterEach(cleanup);

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/apps/frontend/tsconfig.test.json
+++ b/apps/frontend/tsconfig.test.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
+    "target": "es2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "esnext",
+    "types": ["vite/client", "@testing-library/jest-dom"],
+    "allowArbitraryExtensions": true,
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  // src/vite-env.d.tsはimport.meta.envの型を宣言する。テストからsrcを辿ると必要になる
+  "include": ["test", "src/vite-env.d.ts"]
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
@@ -9,5 +9,11 @@ export default defineConfig({
       // Same-origin /api in dev, mirroring CloudFront's /api/* -> Lambda routing
       "/api": "http://localhost:8000",
     },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./test/setup.ts"],
+    // Vitest 4はnode_modulesと.gitしか除外しない為、対象をtest/に限定する
+    include: ["test/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
フロントエンドには自動テストがなく、CIもlint・フォーマット確認・ビルドしか
実行していなかった。Vitest + jsdom + React Testing Libraryを導入し、テスト
62件を追加する。

### 変更内容

- `apps/frontend/test/`へ`src/`と対応する構成でテストを追加
- Vitestのグローバル注入は使わず、`describe` / `it` / `expect` / `vi`を明示的にimport
- `tsconfig.test.json`を`tsconfig.json`のreferencesへ登録し、`npm run build`でもテストを型検査
- 通信境界はMSWを使わず、`vi.mock`と`fetch`のスタブで再現
- `streamChat`は実際の`Response` / `ReadableStream`でストリーミング処理を検証
- CIのfrontendジョブと`make test`へフロントエンドのテストを追加

### テスト方針

issueのチェックリストを見直し、propsをそのまま属性へ渡すだけの確認は型検査で
足りる為に外した。ChatProgressの実行中ステップの導出やDocumentTableの取込可否の
判定など、自前のロジックへ対象を向けている。

検出力も確認した。`stepStatus`・`sse.ts`・`applyUpdate`の実装をそれぞれ壊し、
テストが落ちることを見ている。`applyUpdate`だけが素通りした。試行2件・
`retry_count: 1`では`slice(0, index)`と`slice()`の結果が一致する為で、試行3件へ
変更し、後続の試行が実際に捨てられることを検証するよう直した。

### CI

frontendジョブでは`npm test`を`npm run build`より前に実行する。`make test`は
フロントエンドとバックエンドの両方を実行する。

### その他

`npm audit`が報告する5件はreact-routerやpostcssなど既存の依存によるもので、
今回追加したdevDependenciesが原因ではない。

---

test(frontend): set up Vitest with jsdom and React Testing Library
test(frontend): add tests for the lib, api and component layers
docs: document the frontend test setup

Closes #50
