### PR TITLE
Add Powertools metrics, X-Ray tracing and a DLQ alarm

### DIFF
--- a/apps/backend/app/ingest/chunking.py
+++ b/apps/backend/app/ingest/chunking.py
@@ -3,6 +3,8 @@
 langchain-text-splittersはlangchain-coreを引き込みworkerイメージを重くする為、自前実装する(ADR-0003)。
 """
 
+from app.tracer import tracer
+
 # 1チャンクの最大文字数と文脈を維持するために隣接チャンク間で重複させる文字数
 CHUNK_SIZE = 500
 CHUNK_OVERLAP = 50
@@ -10,6 +12,8 @@ CHUNK_OVERLAP = 50
 SEPARATORS = ("\n\n", "\n", " ", "")
 
 
+# チャンク全文はセグメントの上限(64KB)を超え得る為、戻り値は記録しない
+@tracer.capture_method(capture_response=False)
 def split_text(
     text: str,
     *,

--- a/apps/backend/app/ingest/embeddings.py
+++ b/apps/backend/app/ingest/embeddings.py
@@ -7,6 +7,8 @@ LangChainを入れない方針(ADR-0003)のため、既定依存のhttpxでREST 
 
 import httpx
 
+from app.tracer import tracer
+
 COHERE_EMBED_URL = "https://api.cohere.com/v2/embed"
 # S3 Vectorsインデックスの次元数(data-stack.tsのdimensionと一致させる)
 EMBEDDING_DIMENSION = 1536
@@ -32,6 +34,8 @@ class CohereEmbedder:
         self._client = client or httpx.Client(timeout=REQUEST_TIMEOUT_SECONDS)
         self._headers = {"Authorization": f"Bearer {api_key}"}
 
+    # ベクトルはセグメントの上限(64KB)を超える為、戻り値は記録しない
+    @tracer.capture_method(capture_response=False)
     def embed_documents(self, texts: list[str]) -> list[list[float]]:
         vectors: list[list[float]] = []
         for start in range(0, len(texts), MAX_TEXTS_PER_REQUEST):

--- a/apps/backend/app/ingest/extract.py
+++ b/apps/backend/app/ingest/extract.py
@@ -8,6 +8,8 @@ from pathlib import PurePosixPath
 
 from pypdf import PdfReader
 
+from app.tracer import tracer
+
 PDF_EXTENSIONS = {".pdf"}
 TEXT_EXTENSIONS = {".md", ".markdown", ".txt"}
 SUPPORTED_EXTENSIONS = PDF_EXTENSIONS | TEXT_EXTENSIONS
@@ -24,6 +26,8 @@ class EmptyDocumentError(Exception):
     """テキストを1文字も抽出できなかったことを表す(画像だけのPDFなど)。"""
 
 
+# 抽出したテキスト全文はセグメントの上限(64KB)を超え得る為、戻り値は記録しない
+@tracer.capture_method(capture_response=False)
 def extract_text(*, filename: str, body: bytes) -> str:
     """ファイル名の拡張子から形式を判定してテキストを抽出する。
 

--- a/apps/backend/app/ingest/vectors.py
+++ b/apps/backend/app/ingest/vectors.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import boto3
 
+from app.tracer import tracer
+
 # PutVectors / DeleteVectorsのAPI上限は500件。
 # 1ベクトルは1536次元 + チャンク本文を含み1リクエストが大きくなるため控えめにする
 MAX_VECTORS_PER_REQUEST = 100
@@ -23,6 +25,7 @@ class VectorIndex:
         self._index_arn = index_arn
         self._client = client or boto3.client("s3vectors")
 
+    @tracer.capture_method
     def put_chunks(
         self,
         *,

--- a/apps/backend/app/ingest_handler.py
+++ b/apps/backend/app/ingest_handler.py
@@ -10,18 +10,29 @@ SQSはbatchSize=1の為、そのメッセージだけが再試行され、maxRec
 import json
 from typing import Any
 
+from aws_lambda_powertools.metrics import MetricUnit
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
 from app.ingest.pipeline import IngestPipeline, get_ingest_pipeline
 from app.ingest_queue import IngestMessage
 from app.logger import logger
+from app.metrics import (
+    DOCUMENT_INGEST_FAILURES,
+    DOCUMENTS_INGESTED,
+    INGESTED_CHUNKS,
+    metrics,
+)
 from app.repositories.documents import DocumentStatusError
+from app.tracer import tracer
 
 FAILED_ALLOWED_FROM = ("processing", "failed", "ingested")
 
 
 # Lambdaのコンテキスト情報(function_nameやaws_request_id等)を全ログへ付与する
 @logger.inject_lambda_context
+@tracer.capture_lambda_handler
+# 取込失敗でもfinallyでフラッシュされる為、失敗のメトリクスも発行される
+@metrics.log_metrics
 def handler(event: dict[str, Any], context: LambdaContext) -> None:
     """SQSイベントのRecordsを取り出し、1件ずつ取込処理へ渡す。
 
@@ -47,8 +58,15 @@ def _process_record(record: dict[str, Any]) -> None:
             user_id=user_id,
             s3_key=message["s3Key"],
         )
+        metrics.add_metric(name=DOCUMENTS_INGESTED, unit=MetricUnit.Count, value=1)
+        metrics.add_metric(
+            name=INGESTED_CHUNKS, unit=MetricUnit.Count, value=chunk_count
+        )
         logger.info("document ingest completed", chunk_count=chunk_count)
     except Exception:
+        metrics.add_metric(
+            name=DOCUMENT_INGEST_FAILURES, unit=MetricUnit.Count, value=1
+        )
         logger.exception("document ingest failed")
         _mark_failed(pipeline, user_id=user_id, document_id=document_id)
         raise

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,11 +1,13 @@
 import importlib.util
 import json
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, FastAPI, Request
 
 from app.logger import logger
 from app.routers import chats, documents, users
+from app.tracer import restore_trace_context, traced_request
 
 # 末尾スラッシュの自動リダイレクトを無効化する。
 # 307のLocationはリクエストのHostから組み立てられ、CloudFrontはOriginへのHostとして
@@ -14,35 +16,37 @@ from app.routers import chats, documents, users
 app = FastAPI(redirect_slashes=False)
 
 
-def _lambda_request_id(request: Request) -> str | None:
-    """Lambda Web Adapterが転送するLambda contextからrequest IDを取り出す。"""
+def _lambda_context(request: Request) -> dict[str, Any]:
+    """Lambda Web Adapterが転送するLambda contextを取り出す。
+
+    request IDとX-RayのトレースIDは、どちらもこのヘッダーからしか得られない。
+    """
     header = request.headers.get("x-amzn-lambda-context")
     if not header:
-        return None
+        return {}
     try:
-        return json.loads(header).get("request_id")
-    except (json.JSONDecodeError, AttributeError):
-        return None
+        context = json.loads(header)
+    except json.JSONDecodeError:
+        return {}
+    return context if isinstance(context, dict) else {}
 
 
 @app.middleware("http")
 async def request_logging_middleware(request: Request, call_next):
-    """全リクエストに追跡用のRequest IDを採番し、ログとレスポンスヘッダーに付与する。
+    """全リクエストに追跡用のRequest IDを採番し、ログ・トレース・レスポンスヘッダーへ付与する。
 
     Lambda contextのaws_request_idを引き継ぎ、無い場合はUUIDで代替する。
-
-    Args:
-        request: リクエスト情報(ヘッダー、URL、ボディ等)
-        call_next: 次の処理(ルーター関数)へリクエストを渡す非同期関数
-
-    Returns:
-        X-Request-Idヘッダーを付与したレスポンス
     """
+    context = _lambda_context(request)
     # ローカル実行などLambda contextがない場合はUUIDで代替する
-    request_id = _lambda_request_id(request) or str(uuid.uuid4())
+    request_id = context.get("request_id") or str(uuid.uuid4())
     request.state.request_id = request_id
     logger.append_keys(request_id=request_id)
-    response = await call_next(request)
+    restore_trace_context(context.get("xray_trace_id"))
+
+    with traced_request("## request", request_id):
+        response = await call_next(request)
+
     response.headers["X-Request-Id"] = request_id
     logger.info(
         "request completed",

--- a/apps/backend/app/metrics.py
+++ b/apps/backend/app/metrics.py
@@ -1,0 +1,19 @@
+"""ビジネスメトリクスの共有インスタンスとメトリクス名。
+
+名前空間はPOWERTOOLS_METRICS_NAMESPACEから解決される。
+CloudWatchのカスタムメトリクスは無料枠が10シリーズ(メトリクス名とディメンションの組み合わせ)である為、
+発行はここに定義した5種・計7シリーズに限る(architecture.md 10.1)。
+"""
+
+from aws_lambda_powertools import Metrics
+
+metrics = Metrics()
+
+# ingest-fn
+DOCUMENTS_INGESTED = "DocumentsIngested"
+DOCUMENT_INGEST_FAILURES = "DocumentIngestFailures"
+INGESTED_CHUNKS = "IngestedChunks"
+
+# chat-fn
+ANSWERS_GRADED = "AnswersGraded"
+CHAT_RETRIES = "ChatRetries"

--- a/apps/backend/app/rag/stream.py
+++ b/apps/backend/app/rag/stream.py
@@ -11,9 +11,11 @@ from collections.abc import AsyncGenerator
 from itertools import zip_longest
 from typing import Any, NamedTuple
 
+from aws_lambda_powertools.metrics import MetricUnit, single_metric
 from langchain_core.documents import Document
 
 from app.logger import logger
+from app.metrics import ANSWERS_GRADED, CHAT_RETRIES, metrics
 from app.rag.runtime import RagRuntime
 from app.repositories.chats import ChatRepository, RetrievedDocument
 
@@ -112,6 +114,27 @@ def persist(
         )
 
 
+def record_metrics(state: dict[str, Any]) -> None:
+    """完走したチャット1件分のメトリクスを発行する。
+
+    grade別の件数を数えるにはディメンションへ値を持たせる必要があるが、既定のEMFへ足すと
+    同じEMFに載るChatRetriesにもgradeが付き、メトリクスシリーズが3倍になる。
+    その為AnswersGradedだけ独立したEMFとして出す。
+    """
+    grades = state.get("grade") or []
+    if grades:
+        with single_metric(
+            name=ANSWERS_GRADED, unit=MetricUnit.Count, value=1
+        ) as metric:
+            metric.add_dimension(name="grade", value=grades[-1])
+
+    metrics.add_metric(
+        name=CHAT_RETRIES, unit=MetricUnit.Count, value=state.get("retry_count", 0)
+    )
+    # chat-fnはLambdaハンドラーを持たない為、log_metricsの代わりに自分でフラッシュする
+    metrics.flush_metrics()
+
+
 async def generate_sse(
     *,
     runtime: RagRuntime,
@@ -121,7 +144,11 @@ async def generate_sse(
     chat_id: str,
     request_id: str,
 ) -> AsyncGenerator[str, None]:
-    """ノードごとのstate更新をSSEで配信し、完了後にdoneイベントを返す。"""
+    """ノードごとのstate更新をSSEで配信し、完了後にdoneイベントを返す。
+
+    メトリクスはグラフが完走したときだけ発行する。失敗時とクライアント切断時に出さないのは、
+    永続化と同じ基準(部分的なチャットは記録しない)に揃える為である。
+    """
     logger.info("chat stream started", chat_id=chat_id, question=question[:50])
 
     final_state: dict[str, Any] = {}
@@ -165,6 +192,8 @@ async def generate_sse(
             {"message": "チャットの生成に失敗しました。", "requestId": request_id},
         )
         return
+
+    record_metrics(final_state)
 
     grades = final_state.get("grade") or []
     logger.info("chat stream finished", chat_id=chat_id)

--- a/apps/backend/app/tracer.py
+++ b/apps/backend/app/tracer.py
@@ -1,0 +1,51 @@
+"""X-Rayトレースの共有インスタンスと、サブセグメントを開くヘルパー。
+
+Tracerはlogger.pyと同様にプロセス内で1つを共有する。
+Lambda外(ローカル開発・pytest)ではPowertoolsがX-Ray SDKごと無効化する為、
+計装は全てダミーのサブセグメントになり、外部への送信も起きない。
+
+patch_allは導入済みのライブラリを全て走査してコールドスタートを伸ばす為、対象を絞る。
+botocoreがDynamoDB / S3 / SQS / S3 Vectors / SSM、httpxがCohereのEmbedding呼び出しを覆う。
+
+chat-fnではPOWERTOOLS_TRACE_DISABLEDによりTracerを無効化している。RAGパイプラインが
+検索を並行実行し、X-Ray SDKのスレッドローカルなコンテキストが壊れる為である(ADR-0014)。
+"""
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from aws_lambda_powertools import Tracer
+
+# LambdaランタイムがX-Rayのトレースコンテキストを渡す環境変数。X-Ray SDKはここから親を組み立てる
+LAMBDA_TRACE_HEADER_KEY = "_X_AMZN_TRACE_ID"
+
+tracer = Tracer(patch_modules=("botocore", "httpx"))
+
+
+def restore_trace_context(xray_trace_id: str | None) -> None:
+    """Lambda Web Adapterが転送するトレースIDから、X-Ray SDKのトレースコンテキストを復元する。
+
+    LWAはX-Rayのトレースヘッダーをアプリへ転送せず、Lambdaランタイムが呼び出しごとに更新する
+    `_X_AMZN_TRACE_ID`もアプリのプロセスからは見えない。唯一の入力が`x-amzn-lambda-context`の
+    トレースIDである為、これをX-Ray SDKが読む環境変数へ書き戻して親セグメントの足場を作る。
+
+    SDKは保持中のセグメントとトレースIDが変わると、それまでのサブセグメントを破棄して
+    組み立て直す。FastAPIが同期の依存関係を動かすワーカースレッドからも同じ環境変数を読む為、
+    スレッドを跨いでも同一トレースに紐づく。
+    """
+    if xray_trace_id:
+        os.environ[LAMBDA_TRACE_HEADER_KEY] = xray_trace_id
+
+
+@contextmanager
+def traced_request(name: str, request_id: str) -> Iterator[None]:
+    """request IDをアノテーションに付けたサブセグメントの中で処理を実行する。
+
+    アノテーションはX-Rayの検索キーになる為、ログのrequest_idからトレースを引ける。
+    トレースコンテキストを復元できなかった場合はサブセグメントがNoneで返るため、その場合は何もしない。
+    """
+    with tracer.provider.in_subsegment(name=name) as subsegment:
+        if subsegment is not None:
+            subsegment.put_annotation("request_id", request_id)
+        yield

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -5,7 +5,8 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "aws-lambda-powertools>=3.7.0",
+    # tracer extraはX-Ray SDK(aws-xray-sdk)を追加する
+    "aws-lambda-powertools[tracer]>=3.7.0",
     "boto3>=1.43.51",
     "fastapi>=0.139.2",
     "httpx>=0.28.1",

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -1,5 +1,7 @@
+import json
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any, NamedTuple
 
 import boto3
 import jwt
@@ -9,6 +11,7 @@ from jwt import PyJWKClient
 from moto import mock_aws
 
 from app.ingest.pipeline import get_ingest_pipeline
+from app.metrics import metrics
 from app.rag.runtime import get_rag_runtime
 from app.settings import get_settings
 from app.ssm import get_parameter
@@ -23,6 +26,41 @@ VECTOR_INDEX_ARN = (
 )
 OPENAI_API_KEY_PARAMETER_NAME = "/event-driven-rag/test-openai-api-key"
 COHERE_API_KEY_PARAMETER_NAME = "/event-driven-rag/test-cohere-api-key"
+METRICS_NAMESPACE = "test-namespace"
+
+
+class EmittedMetric(NamedTuple):
+    name: str
+    value: Any
+    dimensions: dict[str, str]
+
+
+def emitted_metrics(captured_stdout: str) -> list[EmittedMetric]:
+    """capsysで拾った標準出力から、発行されたメトリクスを取り出す。
+
+    PowertoolsのMetricsは標準出力へEMF形式のJSONを1行で書き出す。
+    構造化ログも同じ標準出力へJSONで出る為、EMFの目印である`_aws`キーで選り分ける。
+    """
+    emitted: list[EmittedMetric] = []
+    for line in captured_stdout.splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict) or "_aws" not in payload:
+            continue
+        for definition in payload["_aws"]["CloudWatchMetrics"]:
+            # Dimensionsはディメンション名の配列の配列。値は同じEMFの直下にある
+            names = definition["Dimensions"][0] if definition["Dimensions"] else []
+            emitted.extend(
+                EmittedMetric(
+                    name=metric["Name"],
+                    value=payload[metric["Name"]],
+                    dimensions={name: payload[name] for name in names},
+                )
+                for metric in definition["Metrics"]
+            )
+    return emitted
 
 
 # autouse=Trueにより、テスト関数に引数(env)を書かなくても、test/の全テスト実行前に自動で呼ばれる
@@ -38,6 +76,10 @@ def env(monkeypatch):
     monkeypatch.setenv("VECTOR_INDEX_ARN", VECTOR_INDEX_ARN)
     monkeypatch.setenv("OPENAI_API_KEY_PARAMETER_NAME", OPENAI_API_KEY_PARAMETER_NAME)
     monkeypatch.setenv("COHERE_API_KEY_PARAMETER_NAME", COHERE_API_KEY_PARAMETER_NAME)
+    # 共有インスタンスは名前空間をimport時に解決し終えている為、環境変数だけでは届かない。
+    # 環境変数の方は、呼び出しごとにproviderを作るsingle_metricが読む
+    monkeypatch.setenv("POWERTOOLS_METRICS_NAMESPACE", METRICS_NAMESPACE)
+    monkeypatch.setattr(metrics.provider, "namespace", METRICS_NAMESPACE)
     # motoが本物のAWS鍵を使って実AWSリソースにリクエストしないようダミーを設定
     monkeypatch.setenv("AWS_DEFAULT_REGION", "ap-northeast-1")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
@@ -49,6 +91,8 @@ def env(monkeypatch):
 
 def _clear_caches() -> None:
     """プロセス内キャッシュがテスト間で漏れないようまとめてクリアする。"""
+    # Metricsは単一インスタンスで、未フラッシュのメトリクスを保持し続ける
+    metrics.clear_metrics()
     get_settings.cache_clear()
     get_parameter.cache_clear()
     get_rag_runtime.cache_clear()

--- a/apps/backend/tests/test_chat_stream_api.py
+++ b/apps/backend/tests/test_chat_stream_api.py
@@ -11,8 +11,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.metrics import ANSWERS_GRADED, CHAT_RETRIES
 from app.rag.graph import build_graph
 from app.rag.runtime import RagRuntime, get_rag_runtime
+from app.rag.stream import generate_sse
+from app.repositories.chats import ChatRepository
+from tests.conftest import TABLE_NAME, emitted_metrics
 from tests.rag.fakes import (
     FakeReranker,
     FakeRetriever,
@@ -245,6 +249,63 @@ def test_graph_failure_emits_error_event_and_persists_nothing(
     assert error["requestId"]
     # 途中結果は保存しない
     assert aws.table.scan()["Items"] == []
+
+
+def test_emits_grade_and_retry_metrics_on_completion(
+    make_token, aws, override_runtime, capsys
+):
+    """gradeはディメンションで数える為、リトライ件数とは別のEMFで発行する。"""
+    override_runtime(
+        make_runtime(
+            chains=build_fake_chains(
+                queries=[["q1", "q2", "q3"], ["r1", "r2", "r3"]],
+                answers=["不十分な回答", "十分な回答"],
+                grades=[("useless", "情報が不足"), ("useful", "十分")],
+            )
+        )
+    )
+
+    post_stream(make_token)
+
+    metrics = {
+        metric.name: metric for metric in emitted_metrics(capsys.readouterr().out)
+    }
+    assert metrics[ANSWERS_GRADED].dimensions == {"grade": "useful"}
+    assert metrics[ANSWERS_GRADED].value == [1]
+    assert metrics[CHAT_RETRIES].value == [1]
+    assert "grade" not in metrics[CHAT_RETRIES].dimensions
+
+
+def test_emits_no_metrics_when_graph_fails(make_token, aws, override_runtime, capsys):
+    class ExplodingChain:
+        async def ainvoke(self, inputs, config=None):
+            raise RuntimeError("OpenAIが応答しません")
+
+    override_runtime(
+        make_runtime(
+            chains=replace(build_fake_chains(), generate_queries=ExplodingChain())
+        )
+    )
+
+    post_stream(make_token)
+
+    assert emitted_metrics(capsys.readouterr().out) == []
+
+
+async def test_emits_no_metrics_when_client_disconnects(aws, capsys):
+    """SSEを最後まで読まずに切断された場合、完走していない為メトリクスを出さない。"""
+    stream = generate_sse(
+        runtime=make_runtime(),
+        repository=ChatRepository(TABLE_NAME),
+        question="設計方針は?",
+        user_id="user-123",
+        chat_id="01JCHAT000000000000000000",
+        request_id="req-1",
+    )
+    await anext(stream)
+    await stream.aclose()
+
+    assert emitted_metrics(capsys.readouterr().out) == []
 
 
 def test_requires_authentication(aws, override_runtime):

--- a/apps/backend/tests/test_ingest_handler.py
+++ b/apps/backend/tests/test_ingest_handler.py
@@ -15,8 +15,14 @@ from app.ingest.extract import UnsupportedFileTypeError
 from app.ingest.pipeline import DocumentNotFoundError, IngestPipeline
 from app.ingest.vectors import VectorIndex
 from app.ingest_handler import handler
+from app.metrics import DOCUMENT_INGEST_FAILURES, DOCUMENTS_INGESTED, INGESTED_CHUNKS
 from app.repositories.documents import DocumentRepository
-from tests.conftest import BUCKET_NAME, TABLE_NAME, VECTOR_INDEX_ARN
+from tests.conftest import (
+    BUCKET_NAME,
+    TABLE_NAME,
+    VECTOR_INDEX_ARN,
+    emitted_metrics,
+)
 from tests.factories import put_document
 from tests.ingest.test_vectors import StubS3VectorsClient
 
@@ -260,6 +266,46 @@ def test_marks_failed_when_embedding_api_fails(
         handler(build_event(), lambda_context)
 
     assert get_document(aws)["status"] == "failed"
+
+
+def test_emits_ingest_metrics_on_success(aws, pipeline, lambda_context, capsys):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+    )
+    upload(aws, ("段落。" * 400).encode())
+
+    handler(build_event(), lambda_context)
+
+    # EMFの値はデータポイントの配列で出る
+    metrics = {
+        metric.name: metric.value for metric in emitted_metrics(capsys.readouterr().out)
+    }
+    assert metrics.pop(DOCUMENTS_INGESTED) == [1]
+    assert metrics.pop(INGESTED_CHUNKS) == [int(get_document(aws)["chunkCount"])]
+    assert metrics == {}
+
+
+def test_emits_failure_metric_when_ingest_fails(aws, pipeline, lambda_context, capsys):
+    put_document(
+        aws.table,
+        user_id=USER_ID,
+        document_id=DOCUMENT_ID,
+        filename=FILENAME,
+        status="processing",
+    )
+
+    with pytest.raises(ClientError):
+        handler(build_event(), lambda_context)
+
+    # 例外を再送出してもlog_metricsがフラッシュする
+    metrics = {
+        metric.name: metric.value for metric in emitted_metrics(capsys.readouterr().out)
+    }
+    assert metrics == {DOCUMENT_INGEST_FAILURES: [1]}
 
 
 def test_unknown_document_raises_without_creating_item(aws, pipeline, lambda_context):

--- a/apps/backend/tests/test_request_context.py
+++ b/apps/backend/tests/test_request_context.py
@@ -1,0 +1,65 @@
+"""Lambda Web Adapterが転送するLambda contextの取り回しに関するテスト。
+
+request IDとX-RayのトレースIDは、どちらも`x-amzn-lambda-context`からしか得られない。
+"""
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.tracer import LAMBDA_TRACE_HEADER_KEY
+
+client = TestClient(app)
+
+TRACE_HEADER = (
+    "Root=1-65c0ffee-0123456789abcdef01234567;Parent=53995c3f42cd8ad8;Sampled=1"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_trace_context(monkeypatch):
+    """トレースコンテキストはプロセスの環境変数を介して渡る為、テスト間で持ち越さない。"""
+    monkeypatch.setenv(LAMBDA_TRACE_HEADER_KEY, "")
+
+
+def lambda_context_header(**context) -> dict[str, str]:
+    return {"x-amzn-lambda-context": json.dumps(context)}
+
+
+def test_uses_lambda_request_id_for_tracking():
+    res = client.get(
+        "/api/health", headers=lambda_context_header(request_id="lambda-request-id")
+    )
+
+    assert res.headers["X-Request-Id"] == "lambda-request-id"
+
+
+def test_restores_xray_trace_context_from_lambda_context():
+    """LWAはX-Rayのトレースヘッダーを転送しない為、Lambda contextの値から復元する。"""
+    client.get(
+        "/api/health",
+        headers=lambda_context_header(
+            request_id="lambda-request-id", xray_trace_id=TRACE_HEADER
+        ),
+    )
+
+    assert os.environ[LAMBDA_TRACE_HEADER_KEY] == TRACE_HEADER
+
+
+def test_generates_request_id_without_lambda_context():
+    """ローカル実行ではLambda contextが無く、トレースコンテキストも復元しない。"""
+    res = client.get("/api/health")
+
+    assert res.headers["X-Request-Id"]
+    assert os.environ[LAMBDA_TRACE_HEADER_KEY] == ""
+
+
+def test_ignores_broken_lambda_context():
+    res = client.get("/api/health", headers={"x-amzn-lambda-context": "not-json"})
+
+    assert res.status_code == 200
+    assert res.headers["X-Request-Id"]
+    assert os.environ[LAMBDA_TRACE_HEADER_KEY] == ""

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -46,6 +46,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/e1/67a119333cb3656b9b482a77bb4b25e0488ca969218b71479b4ecfc1a5e1/aws_lambda_powertools-3.31.1-py3-none-any.whl", hash = "sha256:cd03f824bc11b59df727744fa9a419a01772d85fd0b15a67eee07f5472b37c77", size = 957593, upload-time = "2026-07-13T09:22:09.354Z" },
 ]
 
+[package.optional-dependencies]
+tracer = [
+    { name = "aws-xray-sdk" },
+]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/25/0cbd7a440080def5e6f063720c3b190a25f8aa2938c1e34415dc18241596/aws_xray_sdk-2.15.0.tar.gz", hash = "sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365", size = 76315, upload-time = "2025-10-29T20:59:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c3/f30a7a63e664acc7c2545ca0491b6ce8264536e0e5cad3965f1d1b91e960/aws_xray_sdk-2.15.0-py2.py3-none-any.whl", hash = "sha256:422d62ad7d52e373eebb90b642eb1bb24657afe03b22a8df4a8b2e5108e278a3", size = 103228, upload-time = "2025-10-29T21:00:24.12Z" },
+]
+
 [[package]]
 name = "awslambdaric"
 version = "4.0.1"
@@ -75,7 +93,7 @@ name = "backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "aws-lambda-powertools" },
+    { name = "aws-lambda-powertools", extra = ["tracer"] },
     { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -108,7 +126,7 @@ worker = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aws-lambda-powertools", specifier = ">=3.7.0" },
+    { name = "aws-lambda-powertools", extras = ["tracer"], specifier = ">=3.7.0" },
     { name = "boto3", specifier = ">=1.43.51" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -1893,6 +1911,70 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/4a/d17a0fad1bf1c5f2c887ff71fef75654141b0880bff71d157d955b5bec3a/wrapt-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a45ffae742ce91a16e11cb6c7cd71e7f9994f3cbd283b962ab093f5c6dcf525", size = 82139, upload-time = "2026-07-28T06:04:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/51b92daaf6defb57f4dc56bdcce985400f75c6984a03ca5e78ccac717028/wrapt-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69e477046f2237ef0bc6547544ee73008dc764ca26eff44f09e976d221b34d5d", size = 82723, upload-time = "2026-07-28T06:04:36.502Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d221a6e6ddd302b8397433184e96b59f259f50024b854db1c411a881586b6b8", size = 172381, upload-time = "2026-07-28T06:04:37.674Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/89/ff7814f6eb6856b479946117d1138a2fbb46cdb6b1f379db359056c69743/wrapt-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:392158c9a7f2ab1b8699418bfc0fe6f83548788c418b27d7bf2019ad3405cebb", size = 174120, upload-time = "2026-07-28T06:04:38.987Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1e/8eded8615d39e3ce81f626937a3a87b280a2a86239a2bf14a4b4bb345034/wrapt-2.3.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e5301c35cf75655eb33498f2bd6ae8703ca19940e3167dc9cdf740c712a39c60", size = 163035, upload-time = "2026-07-28T06:04:40.361Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ea/a0af2d9da62897af2a055484920de05dade30d2ba2c0d65cbdea875d3d8b/wrapt-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:418f54bb09d1762db02c7009b4051149893af3153a87f92d70356703c11eea02", size = 171887, upload-time = "2026-07-28T06:04:41.614Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dd/63cd4c864c65ef4906df64bd2d378f4a62b54f28063f282dfb3bf93caead/wrapt-2.3.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1598becd30f8f2777d18564064eb4f4dbe1ab0e05a8f09786d0ef505ac782bf3", size = 161113, upload-time = "2026-07-28T06:04:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ee/82f1fc9e431b5c2c5a6d201aa865dbeae3984c311c6d11a185f0c8367cf6/wrapt-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3da470536bf9645143323dd41b32db55c6f4304ad382094c1a1da8a92061e10d", size = 170530, upload-time = "2026-07-28T06:04:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a5/5dc590e863a419930d988f8b7ca3e75a6befcfb10b6003b3a152f3d5f732/wrapt-2.3.0-cp312-cp312-win32.whl", hash = "sha256:fb8e2e6704a1e0b1b989546c69e2688371ef4a07fa5f61bde3eb6211186f5ac1", size = 78323, upload-time = "2026-07-28T06:04:45.484Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f9/4a6925a07951df56394f7e6ebe14f69f1c5ef9d87aa63e0839acf15aa63a/wrapt-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:cdc021cb0b62471d6aac7f2bd92f3b4658073775f9ee7fcd325c511129e7bcc8", size = 81180, upload-time = "2026-07-28T06:04:47.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4f/8b5de0395b2a72216751d41c9861df6facaeb611b619d8810ed2b3b23eb2/wrapt-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:67bfe2485f50368c3fcd2275fc1fd100e350d601e0058921a7c82678a465aeab", size = 80155, upload-time = "2026-07-28T06:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6e/0f88a072483e76b881e3fdcd6b6ffb4a5791002514fe541e72b1b73c859a/wrapt-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d3fb71e65b001adfc42684522eeccd9c21d8ba679945abc993439567b66e59f", size = 81960, upload-time = "2026-07-28T06:04:49.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ff/b7e2776e7c294075eb712cc9ef573d1b818f393006d09787262b8fc871c4/wrapt-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51a7a4181c1295774812271fbcd7c909df372bc25579d4ed9eb875caaf0ae86f", size = 82435, upload-time = "2026-07-28T06:04:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/343bb5d0f1f9669bc252a6073f085b4abf862511bd5c9c9eaec754341f1d/wrapt-2.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9045917809c63fdf7abe3a2ceaed3d670b8ee4500ddd9291192d30aeb34467c5", size = 170350, upload-time = "2026-07-28T06:04:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f8/13b79a392930bd0dd6b86cbfbfe1c40944110456e1dc6d809e5c46ece904/wrapt-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54ca1d5573f69b5fe1d74f1f65799c68015e82f685efec9fd8cfa40a094c44d0", size = 170022, upload-time = "2026-07-28T06:04:53.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/4f1b6918f5290db959d6e0c07f77385d87cede29c39c9cf8f145e9c82954/wrapt-2.3.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:242b60c21e30866e6a2fa606c612b47c553fa60c0eaeeeb7797fb842ac0ce609", size = 161043, upload-time = "2026-07-28T06:04:54.936Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/45d3cf74414780bdff6d0380467e003f6eb0f028b6c9403db868dbc7209c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3f3d7ec0a51fbfe00d3aef047641ff2c58b25565b4717fc1f90e050be01cba8", size = 168576, upload-time = "2026-07-28T06:04:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/73/2fa58dd97f191c997755e2c6d569a68f0c433db4e4b36099bdd7227b6cac/wrapt-2.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:261f53870cd4fb2bf38f9f972c56c728fd224cb7c65721307de59d9e7e6741ae", size = 159140, upload-time = "2026-07-28T06:04:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a8/08a56e2000a8816d449dcbad8c8b081697acbbd490821ceca0f9d8e8d20c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8159ec0b0cb7608175eb150de94c19e34f4d47ac655f5ca9baf45df6b688ffd3", size = 169263, upload-time = "2026-07-28T06:04:59.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/354e1725e35a73b2af4fa70a3e024c7a5d1bf1802dfb862dcb668aae0253/wrapt-2.3.0-cp313-cp313-win32.whl", hash = "sha256:10461884b3014fbfc8eb7d09a93c5f246363e6711d9d881f95eb8c27fdef049f", size = 78241, upload-time = "2026-07-28T06:05:00.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/34c87fa2174848dfee820322aaa318bab08913998ccecc8d2f57b4ad4639/wrapt-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac870cc97b73bb00ac353329e9559a4bebc47c4c86792ed9b23b58c15b6ad838", size = 81113, upload-time = "2026-07-28T06:05:01.839Z" },
+    { url = "https://files.pythonhosted.org/packages/11/86/fcc9a530579e008c9478bb565a6cdfbfd33536660f069c8b91a6607c5050/wrapt-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:a65e8db2b4e90c2e7ade931086351c98ef420bf7a94ee08c95ac8a3cbbc43579", size = 80182, upload-time = "2026-07-28T06:05:03.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/50/3864848b95b28ef73e17551fc8dccbff2628a834f52cf26a57f9c419fb83/wrapt-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:fd1f2f557dd3491fe75905e578f4db967393d40d1a8f468edc4d40ac7f2d5944", size = 83921, upload-time = "2026-07-28T06:05:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/3d1921a60c3e8c71c540ff136e6a47a1fbccf7f671e818394889f7871d9c/wrapt-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9f5d2aec29dfc76c37e23897dee92766a3fd4f3bff3ae7fc9c6b4bf37d8c1360", size = 84412, upload-time = "2026-07-28T06:05:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1a/4a796ff7adb26ada6d4b758c94d47a38320b085e7099afc088efbbcdb006/wrapt-2.3.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:646d20d413ffcd1b0a2f700076e2d0252d872dcb7754860a73e45a59ea883614", size = 207168, upload-time = "2026-07-28T06:05:07.256Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3e/d7777776806c579b761bac2f91721dda9f04c7a1b380213c5935cc750ae6/wrapt-2.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379f670f45b7bb8993edd9f6fc36c6cc65edb81cffa0b504be34acb0303fff0a", size = 214351, upload-time = "2026-07-28T06:05:08.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/2d64d394df7bf181955b3bb562bf33c4492fb4be113f53071106d43ad8b5/wrapt-2.3.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6208f302f110295d64b22a7ac96500c791bf492dce4366e622e4912b077c9687", size = 199020, upload-time = "2026-07-28T06:05:10.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/fb31d3db7d9834d265fb1a27a2adf0ddf51557c67458c97b22439ad6ae3d/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ed635a9ca4f3a5a2b900c10c69e823373bc00ebc114b459383596d3487da3570", size = 209969, upload-time = "2026-07-28T06:05:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/8724b5da582e62070dc9bf4d8bf1972f317297eefd7ba1f2b5c6393ccf6c/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e3b9eaa742ae7a0aaaaad4ca4b69469d757af2d6e6663ef1dadc47adec0aeb41", size = 196324, upload-time = "2026-07-28T06:05:13.557Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/3d9ef411149543016ee6bcf3af707f787cebd946527452b94bf122e9b7b4/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d0f7284f88f4833705132d06d3b425a43095c2cbd07c58166aac3ab646ba12a4", size = 202610, upload-time = "2026-07-28T06:05:15.048Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9b/4fc042ceb757866dd4a5fc057b3b736f2b360d3703ce9f830d83dc9226e0/wrapt-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:7ebb274aba688b043429eb1500ff8a76ce0cb8ac0812ca3e301f06247b8722b3", size = 79178, upload-time = "2026-07-28T06:05:16.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/b94878f8eed809ca042685276bcea9f24e8c2ca7c9653bb80bbb920a68a5/wrapt-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c4bded758ad6f03b965830944a2f0bc5b2eb3767fe5a7310134315d1a6610e98", size = 82634, upload-time = "2026-07-28T06:05:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/663e1de5332a71685a729754312d327d4cada767c36e1c5a2db4c8de49e6/wrapt-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:d2cc64539da63e39ffb9c7ede849b6e8ddaaf7b3876b5cfb04efd85a5f3f4eb6", size = 81387, upload-time = "2026-07-28T06:05:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/58/10/b073beaea89bc0d3670a75ff51139430a54b6af7ba7796507730634536dd/wrapt-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea52a0d0f08c584943d5764be0e84efa912c8da23c23e1e285ff2f5641c18fcc", size = 81978, upload-time = "2026-07-28T06:05:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/31/0916d9cebf848ed3f1a0c1888faee421747df77331e4db2bc527a9a85988/wrapt-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd85b0aa88efdb189d6ae2f35f4526943a8f091c38599c9c31478241c819e6a1", size = 82518, upload-time = "2026-07-28T06:05:22.562Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/73/31c1bf0f3384062751c2094dadb314916d70aa9b6bfd26d994b4a7b393fa/wrapt-2.3.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:141ed6211286a9660d8d6702de598b43f0934b4f0eda16393f100a80f501d945", size = 170187, upload-time = "2026-07-28T06:05:23.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/25/fce087d54b79b8905f3c3c9dd5f454bbd8d8acb80b960c4a6aee5b4659b3/wrapt-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e49885a62ec4ee854d1b9e6371fda6afd219917225752abf729a3f36d4df9a5", size = 169288, upload-time = "2026-07-28T06:05:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/0d09e6dddc6b7a7230ac77f50254b5980ab4fcd22976f72f8cc8a0404458/wrapt-2.3.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d6159c9b2fefec02314e1332dbbbfaf960e369dfd26bcf7f8b258b5732065b3", size = 160932, upload-time = "2026-07-28T06:05:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/0913af0d2ec0c43865d32d615f518fea66c13c5c930e489e9b0de248e9a8/wrapt-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24da48596326ef8e448cfa837b454f638713d3531262375f00e5a9681682fc07", size = 169017, upload-time = "2026-07-28T06:05:28.501Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f2/3d1e47ea81b822210f5df1bf942fd90780a75c055243d569b664529dea88/wrapt-2.3.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cd3a2edf0427013736b8127955cec62608c56e53ea47e82812ea32059cda407f", size = 159065, upload-time = "2026-07-28T06:05:30.01Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a5/ef2066ced8e5fca204e2b361e9708e36555b40949c583d997ea3b590817d/wrapt-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fa0df3bff4e7ce45759f33fd39335fe2f60477bb9ecf7b8aa41e7d07ee36a23", size = 168821, upload-time = "2026-07-28T06:05:31.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e1/016104650d4e572fa91506eb396b3dd8efbccc9284fdc1c9479c3d21db28/wrapt-2.3.0-cp314-cp314-win32.whl", hash = "sha256:2935d5454b3f179a29b12cf390ee47246740ba2c3a7545b1b46ba31a5f2a4a0b", size = 78700, upload-time = "2026-07-28T06:05:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/6fdc20a9f2ca304748b3f0819cbf377d55260562777bf0b615431bc3c181/wrapt-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:cc2cea812e5cb179a796b766747e7d3b21088760d8deb95676d482b8c8e6fa7d", size = 81422, upload-time = "2026-07-28T06:05:34.774Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a4/9cbd53bf05746bea2c392af39cb052427a8ec95cbd494d930733d8f44681/wrapt-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:22cc5c0a717bd4da87018ae0bffd4c19c6fb679d3ff357216ba566ab26c76cab", size = 80639, upload-time = "2026-07-28T06:05:36.228Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/6c5e4a0f66ea0d2b2dd267e8dd05a0014eea56840b3c8595d40b0a5d1f91/wrapt-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a6b5984cd65dd639546f0eb4b8eacf1c31cb2fe9fb5c27bffe240987cdb2cf84", size = 84030, upload-time = "2026-07-28T06:05:37.714Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/eb/a1aedf03283bc9cbf8a1783995ddc54e3c5a86878f19002d2c428494f4c5/wrapt-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c88abcf53daef80e01a75c7530e727fa6e2c1888fe83e3dcdba4c96216a1f5c7", size = 84419, upload-time = "2026-07-28T06:05:39.131Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/50d511c0dc5105563849e86daa3e16ac7feef699f79fb05af45ea70107d5/wrapt-2.3.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:85de890ff968196e92dd1ae73a9fb8970495e7650a457b1c9ef0ac3dd550bce2", size = 207171, upload-time = "2026-07-28T06:05:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/59/9b538cf7795217e810699d16bc88b96a830d9b5c403eb2ec2db6b5f2ae81/wrapt-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50f416b74d092bb9f41b424e90dd457f365f7ba4b11de62a23679769a21bd85c", size = 214329, upload-time = "2026-07-28T06:05:42.287Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/28/9935d62b1499e5c8b3d191e99ba4eb31ca237a0b699142011a837e9dc7ea/wrapt-2.3.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39febbee6d77301d31da6996b152ce52452da7c7ef72aba10c2fa976dff9c295", size = 199079, upload-time = "2026-07-28T06:05:43.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/01/4446b80fa2ffa47a3449b250d004ba1c1937f07f64a179608fec735df866/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93513bec052c6cd987f9f580c3df068c8bc4ebae6543736be3ca7ec5959cafcd", size = 209992, upload-time = "2026-07-28T06:05:45.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/07/56f26c9f9979586a021e8148747004aba4498f49458c90b0502969b904e1/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:729126e667da34d251b8ebf8a45ef0c5ddadc21542b3d6e1abf4259ece6508df", size = 196334, upload-time = "2026-07-28T06:05:47.608Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/41/6d7bcc895b0f28b2250e10908f060687b9165429dcd7f22ddb3d4c031b74/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:626b69db2021aa01671ec7bbc9740e558522bd44c18cf2ce69bf3d666a014109", size = 202644, upload-time = "2026-07-28T06:05:49.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/25/7860927edba06b758b8852a6f02e832be715563c67a6795d94350bc81099/wrapt-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:629d73378082c00a8173031f9fb30a3ac6abbc894a5bfdfae71fabc60642d501", size = 79685, upload-time = "2026-07-28T06:05:50.976Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0f/270bafe92fde3b069a39bc01e39ee79340895b335640df861d43d2a51885/wrapt-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:42869085687f0aefd57c0f636c3f9354f8ffb321a8ba9cb52d19beb796e561c5", size = 83104, upload-time = "2026-07-28T06:05:52.405Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b3/af176d79a8515a8a720eccdad9a96f6e31a30abf2865430c8c42adf2fd13/wrapt-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1e5aa486e269b00ed35e64771c7d0ab8096cfd2643405ca8cd60ebedc099a51", size = 81774, upload-time = "2026-07-28T06:05:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]
 
 [[package]]

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -50,12 +50,26 @@ aws acm describe-certificate --region us-east-1 --certificate-arn <取得したA
 ## デプロイ
 
 ```bash
-npx cdk deploy --all
+npx cdk deploy --all -c alarmEmail=you@example.com
 ```
+
+`alarmEmail`はDLQアラームの通知先で、指定を省略するとSNSのサブスクリプションが作られない。既に購読済みの場合は、省略したデプロイで削除されるため毎回指定する。
 
 各スタックは他のスタックのリソースを参照するため、DataStack → AppStack → EdgeStack → CiStackの順にデプロイされる。EdgeStackはCloudFrontの代替ドメイン名へ証明書を関連付けるため、AppStackに加えてCertificateStackにも依存する。
 
 スタック間の参照は`Fn::GetStackOutput`でデプロイ時に解決され、CloudFormationのExportを作らない。参照先のリソースを削除するスタック更新でも、Exportの削除がブロックされることはない。証明書のようにリージョンを跨ぐ参照も同じ仕組みで解決されるため、受け渡し用のカスタムリソースは作られない。
+
+### DLQアラームの購読確認(初回のみ)
+
+DataStackはingest-fnのDLQに対するCloudWatchアラームと、通知用のSNSトピックを作る。通知先のメールアドレスはリポジトリへ残さないため、コンテキスト`alarmEmail`でデプロイ時に渡す。
+
+デプロイ後、AWSから届く購読確認メールの`Confirm subscription`リンクを開く。承認するまで通知は配信されない。購読状態は次のコマンドで確認できる。
+
+```bash
+aws sns list-subscriptions-by-topic --topic-arn <DataStackのAlarmTopicArn出力>
+```
+
+`SubscriptionArn`が`PendingConfirmation`のままなら、まだ承認されていない。
 
 ### 公開ドメインのDNS設定(初回のみ)
 

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -25,6 +25,9 @@ export const API_INTEGRATION_TIMEOUT = cdk.Duration.seconds(29);
 // SSEはストリーム全体が統合タイムアウトに収まる必要があるため、chat-fnのLambdaタイムアウトに合わせる
 export const CHAT_INTEGRATION_TIMEOUT = cdk.Duration.seconds(300);
 
+// CloudWatchのカスタムメトリクスの名前空間。発行するメトリクスはarchitecture.md 10.1を参照
+export const METRICS_NAMESPACE = "EventDrivenRag";
+
 export interface AppStackProps extends cdk.StackProps {
   dataStack: DataStack;
 }
@@ -115,6 +118,8 @@ export class AppStack extends cdk.Stack {
       code: webImage,
       memorySize: 512,
       timeout: cdk.Duration.seconds(30),
+      // X-Rayのセグメントを記録する。トレースは従量課金であり固定費は増えない(ADR-0001)
+      tracing: lambda.Tracing.ACTIVE,
       environment: {
         TABLE_NAME: dataStack.table.tableName,
         DOCUMENTS_BUCKET_NAME: dataStack.documentsBucket.bucketName,
@@ -123,6 +128,7 @@ export class AppStack extends cdk.Stack {
         COGNITO_CLIENT_ID: dataStack.userPoolClient.userPoolClientId,
         POWERTOOLS_SERVICE_NAME: "api",
         POWERTOOLS_LOG_LEVEL: "INFO",
+        POWERTOOLS_METRICS_NAMESPACE: METRICS_NAMESPACE,
       },
     });
 
@@ -137,6 +143,8 @@ export class AppStack extends cdk.Stack {
       code: chatImage,
       memorySize: 1024,
       timeout: cdk.Duration.seconds(300),
+      // Lambda自身のセグメントは記録する。アプリ内の計装のみ環境変数で止める(ADR-0014)
+      tracing: lambda.Tracing.ACTIVE,
       environment: {
         TABLE_NAME: dataStack.table.tableName,
         VECTOR_BUCKET_ARN: dataStack.vectorBucket.attrVectorBucketArn,
@@ -149,6 +157,11 @@ export class AppStack extends cdk.Stack {
         AWS_LWA_INVOKE_MODE: "response_stream",
         POWERTOOLS_SERVICE_NAME: "chat",
         POWERTOOLS_LOG_LEVEL: "INFO",
+        POWERTOOLS_METRICS_NAMESPACE: METRICS_NAMESPACE,
+        // RAGパイプラインはベクトル検索を並行実行し、X-Ray SDKのスレッドローカルな
+        // コンテキストが壊れる。サブセグメントが失われるだけでなく、LLM呼び出しへ
+        // 例外が漏れて再試行を招く為、アプリ内の計装は行わない(ADR-0014)
+        POWERTOOLS_TRACE_DISABLED: "true",
       },
     });
 
@@ -176,6 +189,7 @@ export class AppStack extends cdk.Stack {
         memorySize: 1024,
         // SQSの可視性タイムアウト900秒以内に収める
         timeout: cdk.Duration.seconds(600),
+        tracing: lambda.Tracing.ACTIVE,
         environment: {
           TABLE_NAME: dataStack.table.tableName,
           DOCUMENTS_BUCKET_NAME: dataStack.documentsBucket.bucketName,
@@ -184,6 +198,7 @@ export class AppStack extends cdk.Stack {
           COHERE_API_KEY_PARAMETER_NAME,
           POWERTOOLS_SERVICE_NAME: "ingest",
           POWERTOOLS_LOG_LEVEL: "INFO",
+          POWERTOOLS_METRICS_NAMESPACE: METRICS_NAMESPACE,
         },
       },
     );
@@ -217,6 +232,8 @@ export class AppStack extends cdk.Stack {
       endpointTypes: [apigateway.EndpointType.REGIONAL],
       deployOptions: {
         stageName: "prod",
+        // Lambdaのセグメントとつなげ、サービスマップをAPI Gatewayから始める
+        tracingEnabled: true,
         // 想定は月400〜600チャットであり、通常利用が当たる水準ではない
         throttlingRateLimit: 20,
         throttlingBurstLimit: 40,

--- a/cdk/lib/data-stack.ts
+++ b/cdk/lib/data-stack.ts
@@ -1,9 +1,13 @@
 import * as cdk from "aws-cdk-lib/core";
 import { Construct } from "constructs";
+import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as s3vectors from "aws-cdk-lib/aws-s3vectors";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as snsSubscriptions from "aws-cdk-lib/aws-sns-subscriptions";
 import * as sqs from "aws-cdk-lib/aws-sqs";
 
 // Vite devサーバー。デプロイ済みCognitoを使ってローカルで認証フローを動かす為に常に許可する
@@ -21,6 +25,7 @@ export class DataStack extends cdk.Stack {
   public readonly vectorIndex: s3vectors.CfnIndex;
   public readonly ingestQueue: sqs.Queue;
   public readonly ingestDeadLetterQueue: sqs.Queue;
+  public readonly alarmTopic: sns.Topic;
   public readonly userPool: cognito.UserPool;
   public readonly userPoolClient: cognito.UserPoolClient;
   public readonly userPoolDomain: cognito.UserPoolDomain;
@@ -105,6 +110,38 @@ export class DataStack extends cdk.Stack {
       },
     });
 
+    // 通知先メールは公開リポジトリへ残さない為、cdk.jsonではなくデプロイ時のコンテキストで受け取る。
+    // 未指定ならトピックとアラームだけ作る(購読はマネジメントコンソールからでも追加できる)
+    const alarmEmail = this.node.tryGetContext("alarmEmail") as
+      | string
+      | undefined;
+
+    this.alarmTopic = new sns.Topic(this, "AlarmTopic");
+    if (alarmEmail) {
+      // 購読確認メールの承認は手動(cdk/README.md)
+      this.alarmTopic.addSubscription(
+        new snsSubscriptions.EmailSubscription(alarmEmail),
+      );
+    }
+
+    // DLQへ退避したメッセージは誰も見に行かない為、1件でも積まれたら通知する。
+    // CloudWatchアラームの無料枠は10個であり、監視対象はこの1本に絞る
+    this.ingestDeadLetterQueue
+      .metricApproximateNumberOfMessagesVisible({
+        period: cdk.Duration.minutes(5),
+        statistic: cloudwatch.Stats.MAXIMUM,
+      })
+      .createAlarm(this, "IngestDeadLetterQueueAlarm", {
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator:
+          cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        // 取込が無い期間はメトリクスが送られない。データ欠損をALARMにしない
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarmDescription: "ドキュメント取込がリトライ上限を超えてDLQへ退避した",
+      })
+      .addAlarmAction(new cloudwatchActions.SnsAction(this.alarmTopic));
+
     // Cognito ユーザープール設定
     // 運用形態: 管理者によるユーザー作成および招待メール送信の運用（セルフサインアップは無効化）
     // 詳細仕様は docs/authorization.md, ADR-0004を参照
@@ -162,6 +199,7 @@ export class DataStack extends cdk.Stack {
     new cdk.CfnOutput(this, "IngestQueueUrl", {
       value: this.ingestQueue.queueUrl,
     });
+    new cdk.CfnOutput(this, "AlarmTopicArn", { value: this.alarmTopic.topicArn });
     new cdk.CfnOutput(this, "UserPoolId", { value: this.userPool.userPoolId });
     new cdk.CfnOutput(this, "UserPoolClientId", {
       value: this.userPoolClient.userPoolClientId,

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -129,6 +129,7 @@ exports[`スナップショット 1`] = `
               "Fn::ImportValue": "TestDataStack:ExportsOutputRefIngestQueue2280FF4EF5DFF735",
             },
             "POWERTOOLS_LOG_LEVEL": "INFO",
+            "POWERTOOLS_METRICS_NAMESPACE": "EventDrivenRag",
             "POWERTOOLS_SERVICE_NAME": "api",
             "TABLE_NAME": {
               "Fn::ImportValue": "TestDataStack:ExportsOutputRefTableCD117FA1D18A8047",
@@ -144,6 +145,9 @@ exports[`スナップショット 1`] = `
           ],
         },
         "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "Active",
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -182,6 +186,14 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
             {
               "Action": [
                 "dynamodb:BatchGetItem",
@@ -313,7 +325,9 @@ exports[`スナップショット 1`] = `
             "COHERE_API_KEY_PARAMETER_NAME": "/event-driven-rag/cohere-api-key",
             "OPENAI_API_KEY_PARAMETER_NAME": "/event-driven-rag/openai-api-key",
             "POWERTOOLS_LOG_LEVEL": "INFO",
+            "POWERTOOLS_METRICS_NAMESPACE": "EventDrivenRag",
             "POWERTOOLS_SERVICE_NAME": "chat",
+            "POWERTOOLS_TRACE_DISABLED": "true",
             "TABLE_NAME": {
               "Fn::ImportValue": "TestDataStack:ExportsOutputRefTableCD117FA1D18A8047",
             },
@@ -334,6 +348,9 @@ exports[`スナップショット 1`] = `
           ],
         },
         "Timeout": 300,
+        "TracingConfig": {
+          "Mode": "Active",
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -372,6 +389,14 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
             {
               "Action": [
                 "dynamodb:BatchGetItem",
@@ -541,6 +566,7 @@ exports[`スナップショット 1`] = `
               "Fn::ImportValue": "TestDataStack:ExportsOutputRefDocumentsBucket9EC9DEB9131399C0",
             },
             "POWERTOOLS_LOG_LEVEL": "INFO",
+            "POWERTOOLS_METRICS_NAMESPACE": "EventDrivenRag",
             "POWERTOOLS_SERVICE_NAME": "ingest",
             "TABLE_NAME": {
               "Fn::ImportValue": "TestDataStack:ExportsOutputRefTableCD117FA1D18A8047",
@@ -562,6 +588,9 @@ exports[`スナップショット 1`] = `
           ],
         },
         "Timeout": 600,
+        "TracingConfig": {
+          "Mode": "Active",
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -600,6 +629,14 @@ exports[`スナップショット 1`] = `
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
             {
               "Action": [
                 "sqs:ReceiveMessage",
@@ -909,6 +946,7 @@ exports[`スナップショット 1`] = `
           "Ref": "RestApi0C43BF4B",
         },
         "StageName": "prod",
+        "TracingEnabled": true,
       },
       "Type": "AWS::ApiGateway::Stage",
     },

--- a/cdk/test/__snapshots__/data-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/data-stack.test.ts.snap
@@ -3,6 +3,11 @@
 exports[`スナップショット 1`] = `
 {
   "Outputs": {
+    "AlarmTopicArn": {
+      "Value": {
+        "Ref": "AlarmTopicD01E77F9",
+      },
+    },
     "CognitoDomainUrl": {
       "Value": {
         "Fn::Join": [
@@ -79,6 +84,9 @@ exports[`スナップショット 1`] = `
     },
   },
   "Resources": {
+    "AlarmTopicD01E77F9": {
+      "Type": "AWS::SNS::Topic",
+    },
     "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": {
       "DependsOn": [
         "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
@@ -250,6 +258,36 @@ exports[`スナップショット 1`] = `
       },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
+    },
+    "IngestDeadLetterQueueAlarm84BB4DCB": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "AlarmTopicD01E77F9",
+          },
+        ],
+        "AlarmDescription": "ドキュメント取込がリトライ上限を超えてDLQへ退避した",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "IngestDeadLetterQueue48D59084",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "IngestQueue2280FF4E": {
       "DeletionPolicy": "Delete",

--- a/cdk/test/app-stack.test.ts
+++ b/cdk/test/app-stack.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from 'aws-cdk-lib/assertions';
 import {
   AppStack,
   COHERE_API_KEY_PARAMETER_NAME,
+  METRICS_NAMESPACE,
   OPENAI_API_KEY_PARAMETER_NAME,
 } from '../lib/app-stack';
 import { DataStack } from '../lib/data-stack';
@@ -107,6 +108,29 @@ describe('Lambda', () => {
     expect(env).not.toHaveProperty('OPENAI_API_KEY_PARAMETER_NAME');
     expect(env).toHaveProperty('DOCUMENTS_BUCKET_NAME');
     expect(env).toHaveProperty('VECTOR_INDEX_ARN');
+  });
+
+  test('3関数ともアクティブトレースとメトリクスの名前空間を持つ', () => {
+    for (const serviceName of ['api', 'chat', 'ingest']) {
+      const [, fn] = findFunctionByServiceName(serviceName);
+      expect(fn.Properties.TracingConfig).toEqual({ Mode: 'Active' });
+      expect(fn.Properties.Environment.Variables.POWERTOOLS_METRICS_NAMESPACE).toBe(
+        METRICS_NAMESPACE,
+      );
+    }
+  });
+
+  // 並行実行でX-Ray SDKのコンテキストが壊れる為、chat-fnだけアプリ内の計装を止める(ADR-0014)
+  test('chat-fnのみアプリ内トレースを無効化する', () => {
+    const [, chatFn] = findFunctionByServiceName('chat');
+    expect(chatFn.Properties.Environment.Variables.POWERTOOLS_TRACE_DISABLED).toBe('true');
+
+    for (const serviceName of ['api', 'ingest']) {
+      const [, fn] = findFunctionByServiceName(serviceName);
+      expect(fn.Properties.Environment.Variables).not.toHaveProperty(
+        'POWERTOOLS_TRACE_DISABLED',
+      );
+    }
   });
 
   test('3つのLambdaはそれぞれ別ターゲットのイメージを使う', () => {
@@ -240,6 +264,12 @@ describe('API Gateway', () => {
         expect(props.AuthorizationScopes).toEqual(['openid']);
       }
     }
+  });
+
+  test('ステージでX-Rayのトレースが有効になる', () => {
+    template.hasResourceProperties('AWS::ApiGateway::Stage', {
+      TracingEnabled: true,
+    });
   });
 
   test('ステージにスロットリングの上限が設定される', () => {

--- a/cdk/test/data-stack.test.ts
+++ b/cdk/test/data-stack.test.ts
@@ -153,6 +153,47 @@ describe('SQS', () => {
   });
 });
 
+describe('監視', () => {
+  test('DLQへ1件でも積まれたらアラームが発報する', () => {
+    template.resourceCountIs('AWS::CloudWatch::Alarm', 1);
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+      Namespace: 'AWS/SQS',
+      MetricName: 'ApproximateNumberOfMessagesVisible',
+      Statistic: 'Maximum',
+      Period: 300,
+      Threshold: 1,
+      EvaluationPeriods: 1,
+      ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+      // 取込が無い期間のデータ欠損でALARMにしない
+      TreatMissingData: 'notBreaching',
+      AlarmActions: [{ Ref: Match.stringLikeRegexp('AlarmTopic') }],
+      Dimensions: [
+        {
+          Name: 'QueueName',
+          Value: {
+            'Fn::GetAtt': [Match.stringLikeRegexp('IngestDeadLetterQueue'), 'QueueName'],
+          },
+        },
+      ],
+    });
+  });
+
+  test('通知先はalarmEmail未指定ならサブスクリプションを作らない', () => {
+    template.resourceCountIs('AWS::SNS::Topic', 1);
+    template.resourceCountIs('AWS::SNS::Subscription', 0);
+  });
+
+  test('alarmEmail指定時はメールのサブスクリプションを作る', () => {
+    const app = new cdk.App({ context: { alarmEmail: 'ops@example.com' } });
+    const withEmail = Template.fromStack(new DataStack(app, 'TestDataStackWithEmail'));
+
+    withEmail.hasResourceProperties('AWS::SNS::Subscription', {
+      Protocol: 'email',
+      Endpoint: 'ops@example.com',
+    });
+  });
+});
+
 describe('Cognito', () => {
   test('セルフサインアップ無効・email/name必須のUser Poolが作成される', () => {
     template.hasResourceProperties('AWS::Cognito::UserPool', {

--- a/docs/adr/0014-xray-app-instrumentation-scope.md
+++ b/docs/adr/0014-xray-app-instrumentation-scope.md
@@ -1,0 +1,74 @@
+# ADR-0014: X-Rayのアプリ内計装をapi-fnとingest-fnに限定する
+
+- Status: Accepted
+- Date: 2026-08-16
+
+## Context
+
+architecture.md 10.1はLambda PowertoolsのStructured Logging・Metrics・Tracingの3機能を使うと定めている。Tracingの導入にあたっては、3つのLambdaとAPI Gatewayのステージでアクティブトレースを有効にし、アプリ内にもサブセグメントを追加する方針で実装した。しかしデプロイして実測したところ、2つの制約が明らかになった。
+
+### Lambda Web Adapter配下ではトレースコンテキストを受け取れない
+
+ingest-fnは通常のLambda Handlerであり、X-Ray SDKはランタイムが用意したコンテキストをそのまま使える。一方、api-fnとchat-fnはLambda Web Adapterの配下でuvicornの子プロセスとして動く。Lambda Web Adapterがアプリへ転送するのは`x-amzn-request-context`と`x-amzn-lambda-context`の2ヘッダーだけであり、X-Rayのトレースヘッダーは転送しない。さらに、ランタイムが呼び出しごとに更新する`_X_AMZN_TRACE_ID`も、起動済みの子プロセスからは参照できない。そのためSDKは親セグメントを組み立てられず、サブセグメントは破棄される。
+
+ただし、`x-amzn-lambda-context`のJSONはトレースIDを含む。`main.py`のミドルウェアは既にこのヘッダーからRequest IDを取り出しているため、同じ場所からトレースIDも取得できる。
+
+### 並行実行するとX-Ray SDKのコンテキストが壊れる
+
+chat-fnのRAGパイプラインは、`retriever.map()`でMulti Queryの5クエリを並行に検索する。そして各コルーチンは、Cohereの埋め込みAPIをhttpxで呼ぶ。一方、X-Ray SDK for Pythonのコンテキストはスレッドローカルにトレースエンティティのスタックを持つ。そのため、1つのスレッドで複数のコルーチンがサブセグメントを開閉すると、このスタックが壊れる。
+
+デプロイ環境での実測結果は次のとおりである。
+
+- `AlreadyEndedException: Already ended segment and subsegment cannot be modified.`がlangchain-cohereの埋め込み呼び出しへ伝播し、LangChainが4秒待って再試行した
+- アプリが作ったサブセグメントは1つも送信されず、自動計装されたS3 Vectors・DynamoDB・SSM・CohereのサブセグメントだけがX-Rayへ届いた。しかもそれらは、いずれも存在しない親を指す孤児になった
+
+一方、同じ実装でもapi-fnはリクエスト全体のサブセグメントを、ingest-fnはハンドラーと取込4段のサブセグメントを正しく記録した。どちらも計装した処理が逐次だからである。
+
+## Decision
+
+X-Rayのアプリ内計装はapi-fnとingest-fnに限定し、chat-fnでは`POWERTOOLS_TRACE_DISABLED`によりTracerを無効化する。ただしアクティブトレースは3関数とも有効のままとし、Lambda自身のセグメントは記録する。
+
+また、api-fnのトレースコンテキストは、`x-amzn-lambda-context`のトレースIDをX-Ray SDKが参照する環境変数へ書き戻して復元する。
+
+chat-fnで計装を行わない理由は次の3点である。
+
+- 監視のための計装が、LLM呼び出しへ例外を持ち込み応答時間を延ばした。つまり、得られる情報より副作用の方が重い
+- サブセグメントは実際には届いておらず、計装の価値がそもそも出ていない
+- Lambdaのセグメントは残るため、サービスマップ・関数単位のレイテンシ・エラー率は失われない。またノードごとの所要時間は、各ノードが出す構造化ログで追える
+
+## Consequences
+
+メリット
+
+- チャットの応答経路にトレースが干渉しない
+- 届かないサブセグメントを作り続けることがなくなる
+- 追加の依存や独自のコンテキスト管理を持ち込まずに済む。実際、chat-fn側の対処は環境変数1つである
+
+デメリット・制約
+
+- chat-fnのDynamoDB・S3 Vectors・Cohere呼び出しの所要時間をX-Rayで確認できない。ただし、チャットの内訳はログで追える
+- 3つのLambdaで計装の粒度が揃わない
+- api-fnのコンテキスト復元は、プロセスの環境変数を介する。これはLambdaが1つの実行環境で1呼び出しずつ処理するために成立する方式であり、コールドスタートとウォームスタートを含む複数のリクエストでトレースが混ざらないことは実測で確認している
+
+見直し条件
+
+- aws-xray-sdk-pythonがasyncioでのコンテキスト伝播に対応した場合、chat-fnの計装を再検討する
+- AWS Distro for OpenTelemetryへ移行する場合は、コンテキスト伝播の仕組みごと入れ替わるため、この判断を前提から見直す
+
+## Alternatives
+
+### AsyncContextへ差し替える
+
+X-Ray SDKは`AsyncContext`を提供しており、トレースエンティティをタスクローカルに持つ。task factoryが並行タスクへエンティティのリストを複製するため、`asyncio.gather`によるスタックの破壊は防げる。
+
+しかし採用しなかった。理由は、`asyncio.to_thread`の配下でコンテキストを失うことである。`AsyncContext`は`asyncio.current_task()`を前提としており、ワーカースレッドではNoneになる。しかもboto3は同期APIであり、S3 Vectorsの検索もDynamoDBの永続化も別スレッドで実行する。そのため、チャットで最も見たい呼び出しのサブセグメントが捨てられる。つまり、並行するHTTP呼び出しの計装と引き換えに、より重要な可視性を失う。加えて、`LambdaContext`を置き換えるとセグメントの生成も自前で行う必要がある。
+
+### chat-fnでhttpxの計装だけを外す
+
+例外は、並行実行されるhttpxの計装から発生している。一方でノード単位のサブセグメントは逐次であるため、httpxを計装対象から外せば残せる。
+
+しかし採用しなかった。理由は、「並行実行する箇所へ計装を足さない」という制約をコードで強制できないことである。RAGパイプラインは今後もノードの追加や並列化が見込まれるため、`asyncio.gather`を1つ足した時点で同じ例外が戻る。そもそも、監視のための仕組みがアプリケーションの書き方を縛る状態は避けたい。
+
+### 計装を残したまま例外を抑止する
+
+例外はSDKの内部で送出されるため、アプリケーション側に捕捉点がない。また`AWS_XRAY_CONTEXT_MISSING`は、コンテキスト不在時の扱いを変える設定であり、この例外には効かない。したがって抑止する手段がなく、選択肢にならない。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -558,7 +558,35 @@ OpenAIとCohereのAPIキーは、SSM Parameter StoreのSecureStringパラメー�
 - Metrics
 - Tracing
 
-Request IDを全サービスで引き継ぎ、1リクエストの処理をサービス横断で追跡できるようにする。
+Request IDを全サービスで引き継ぎ、1リクエストの処理をサービス横断で追跡できるようにする。api-fnが採番したRequest IDは取込メッセージにも載せ、ingest-fnのログへ引き継ぐ。
+
+#### メトリクス
+
+MetricsはEMF形式のJSONを標準出力へ書き出し、CloudWatch Logsがこれを取り込んでカスタムメトリクスとして記録する。名前空間は`EventDrivenRag`とし、発行するのは次の5種である。
+
+| メトリクス | 発行元 | 内容 |
+| --- | --- | --- |
+| DocumentsIngested | ingest-fn | 取込に成功したドキュメント数 |
+| DocumentIngestFailures | ingest-fn | 取込に失敗したドキュメント数 |
+| IngestedChunks | ingest-fn | S3 Vectorsへ登録したチャンク数 |
+| AnswersGraded | chat-fn | 自己評価の結果別の回答数 |
+| ChatRetries | chat-fn | 再試行の発生回数 |
+
+カスタムメトリクスの課金と無料枠の単位は、メトリクス名とディメンションの組み合わせである。この単位で数えると、AnswersGradedは評価結果の3値をディメンションに持つため3つになる。残りは各1つで合計7つとなり、無料枠の10に収まる。なお、api-fnからビジネスメトリクスは発行しない。
+
+chat-fnはLambda Handlerを持たないため、SSEを配信し終えた時点でアプリ側から明示的にフラッシュする。ただし、処理が途中で失敗した場合とクライアントが切断した場合は発行せず、完走したチャットだけを数える。これはDynamoDBへの永続化と基準を揃えたものである。
+
+#### トレース
+
+3つのLambdaとAPI Gatewayのステージでアクティブトレースを有効にし、X-Rayでリクエストの経路とレイテンシを追跡する。アプリ内の計装はapi-fnとingest-fnで行い、DynamoDB・S3・SQS・S3 Vectorsへのboto3呼び出しとCohereへのHTTP呼び出しに加えて、リクエスト全体と取込処理の各段をサブセグメントとして記録する。さらにサブセグメントへはRequest IDをアノテーションとして付け、ログとトレースを相互に辿れるようにする。
+
+ingest-fnは通常のLambda Handlerであり、X-Rayのコンテキストはランタイムから受け取る。一方、api-fnとchat-fnが利用するLambda Web Adapterは、X-Rayのトレースヘッダーをアプリへ転送しない。しかもランタイムが呼び出しごとに更新する環境変数は、アプリのプロセスからは参照できない。そのため、Lambda Web Adapterが転送するLambda contextに含まれるトレースIDからコンテキストを復元する。
+
+ただし、chat-fnではアプリ内の計装を行わない。RAGパイプラインがベクトル検索を並行実行するため、X-Ray SDKのスレッドローカルなコンテキストが壊れるからである。判断の経緯は[ADR-0014](./adr/0014-xray-app-instrumentation-scope.md)に記載する。それでもLambda自身のセグメントは記録されるため、サービスマップと関数単位のレイテンシは得られる。またノードごとの所要時間は、構造化ログで追跡する。
+
+#### アラーム
+
+ingest-fnがリトライ上限を超えると、メッセージはDLQへ退避する。しかし、退避したこと自体は誰も気付けない。そこでDLQのメッセージ数が1以上になるとCloudWatchアラームが発報し、SNSトピック経由でメールへ通知する。なお、通知先アドレスの購読確認は手動で行う。アラームも無料枠が10であり、監視対象はこの1本に絞る。
 
 ### 10.2 CI/CD
 
@@ -622,8 +650,13 @@ ADR-0001で置いた前提である月400件から600件のチャットを想定
 | CloudFront | Free Tier |
 | Cognito | Free Tier |
 | SQS | Free Tier |
+| CloudWatch | Free Tier |
+| X-Ray | Free Tier |
+| SNS | Free Tier |
 
 合計は約$1〜2/月となる。
+
+モニタリングは無料枠に収まる範囲で構成する。カスタムメトリクスは7、アラームは1で、いずれも無料枠の10以内に収める。X-Rayのトレースは月10万件まで無料であり、想定利用量では課金されない。
 
 OpenAIとCohereのAPIは上記とは別に従量課金となる。Self-RAGは1チャットで最大8回のLLM呼び出しが発生するため、補助チェーンにはnano系モデルを使いコストを抑える。
 
@@ -653,6 +686,7 @@ OpenAIとCohereのAPIは上記とは別に従量課金となる。Self-RAGは1�
 - [ADR-0011: api-fnとchat-fnの公開経路をAPI Gatewayへ移行する](./adr/0011-api-gateway-migration.md)
 - [ADR-0012: チャットのSSEをPOSTとAuthorizationヘッダーで配信する](./adr/0012-sse-post-with-authorization-header.md)
 - [ADR-0013: 独自ドメインはサブドメインで公開し、DNSをお名前.comに置く](./adr/0013-custom-domain-subdomain-external-dns.md)
+- [ADR-0014: X-Rayのアプリ内計装をapi-fnとingest-fnに限定する](./adr/0014-xray-app-instrumentation-scope.md)
 
 認証の詳細設計は次のドキュメントで管理する。
 


### PR DESCRIPTION
### 背景・目的

architecture.md 10.1 はPowertoolsのStructured Logging・Metrics・Tracingの3機能を使うと定めている。しかし実装されていたのはStructured Loggingだけで、MetricsとTracerの利用箇所は無かった。さらにCloudWatchアラームも存在せず、ingest-fnのDLQへ退避したメッセージは誰にも気付かれないまま残る状態だった。そこで、設計書に書いた運用設計を実際に動く状態にする。

### 変更内容

- `app/tracer.py` / `app/metrics.py` を追加し、TracerとMetricsの単一インスタンスを共有する
- api-fnのリクエストと、ingest-fnのハンドラー・取込4段をサブセグメントとして計装する
- ingest-fnの成功・失敗・チャンク数、chat-fnのgrade別件数・リトライ回数を発行する
- 3つのLambdaとAPI Gatewayのステージでアクティブトレースを有効にする
- ingest-fnのDLQにCloudWatchアラームを設定し、SNS経由でメール通知する

### 重要な設計判断

**LWA配下のトレースコンテキスト復元。** LWAはX-Rayのトレースヘッダーをアプリへ転送せず、ランタイムが呼び出しごとに更新する `_X_AMZN_TRACE_ID` もアプリのプロセスからは参照できない。そのため唯一の入力である `x-amzn-lambda-context` のトレースIDを同じ環境変数へ書き戻し、X-Ray SDKに親セグメントを組み立てさせている。この方式が成立するかは実測でしか判断できないため、デプロイして確認した。

**chat-fnはアプリ内計装を行わない（ADR-0014）。** 当初は3関数すべてを計装したが、デプロイ実測で問題が出た。原因は、RAGパイプラインが `retriever.map()` で5クエリを並行検索するため、X-Ray SDKのスレッドローカルなコンテキストが壊れることである。その結果、サブセグメントが届かないだけでなく、`AlreadyEndedException` がCohereの埋め込み呼び出しへ伝播し、LangChainが4秒待って再試行していた。監視のための計装がLLM呼び出しに干渉する状態は割に合わない。そこでchat-fnは `POWERTOOLS_TRACE_DISABLED=true` とし、Lambda自身のセグメントだけを残した。なお、代替案として `AsyncContext` への差し替えとhttpx計装のみの除外も検討しており、退けた理由はADRに記載している。

**メトリクスは7シリーズに収める。** 課金と無料枠の単位は、メトリクス名とディメンションの組み合わせである。そのためgradeを既定のEMFへ足すと、同じEMFに載るChatRetriesにもディメンションが付き、シリーズが3倍に増えてしまう。そこでAnswersGradedだけ `single_metric` で独立したEMFとして出している。

**メトリクスは完走したチャットだけを数える。** 失敗時とクライアント切断時には発行しない。これは、部分的なチャットを記録しないというDynamoDBへの永続化の基準に揃えたものである。

**通知先メールはリポジトリへ置かない。** publicリポジトリであるため、cdk.jsonへは置かず、デプロイ時のコンテキスト `alarmEmail` で渡す。

### 検証結果

`make lint` / `make test`（backend 134件）と cdk の typecheck / jest（88件）が通る。加えて、デプロイ環境のDataStackとAppStackに対して次を実測した。

- **api-fn**: `/api/health` を3回叩き、1回目のコールドスタートを含むすべてで、Lambdaセグメントの `Invocation` 配下に `## request` が入り、API Gatewayステージと同一トレースへ収まった。リクエスト間でトレースの混線も起きていない。またアノテーションの `request_id` はLambdaのRequestIdと一致し、ログの `request_id` およびレスポンスの `X-Request-Id` とも同じ値だった
- **ingest-fn**: `## handler` の下に `extract_text` → `split_text` → `embed_documents` → `put_chunks` が並び、`embed_documents` は `api.cohere.com` を、`put_chunks` は `s3vectors` を内包する。S3・DynamoDB・SSMも自動計装された
- **chat-fn（修正前）**: アプリ内サブセグメントが1つも送信されず、自動計装分はすべて存在しない親を指す孤児になった。あわせて `AlreadyEndedException` によるリトライも確認した
- **chat-fn（修正後）**: 例外とリトライは消え、トレースはLambdaセグメントのみになった。一方でメトリクスは変わらず記録される
- **メトリクス**: `DocumentsIngested` / `IngestedChunks` / `AnswersGraded{grade=useful}` / `ChatRetries` が名前空間 `EventDrivenRag` へ記録された。シリーズ数は上限の7以内に収まっている
- **アラーム**: DLQへテストメッセージを1件送ると `OK → ALARM` へ遷移し、SNSアクションの実行成功とメール受信を確認した。確認後にキューはパージしている

### 既知の問題・注意事項

- chat-fnのDynamoDB・S3 Vectors・Cohere呼び出しの所要時間はX-Rayで確認できない。ただしチャットの内訳は、`xray_trace_id` を含む構造化ログで追える
- `alarmEmail` を指定せずに `cdk deploy` すると、CDKはSNSサブスクリプションを削除する。そのため毎回指定するよう cdk/README.md に明記した
- Issueに挙げていた `AWS_XRAY_CONTEXT_MISSING=IGNORE_ERROR` は設定していない。Lambda環境ではSDKが `LambdaContext` を使い、この設定を無視するためである

---

- feat(backend): emit business metrics and X-Ray traces
- feat(cdk): enable active tracing and alarm on the ingest DLQ
- docs(adr): limit the X-Ray app instrumentation to api-fn and ingest-fn
- docs: document the metrics, traces and the DLQ alarm

Closes #52
