### PR TITLE
Run the Lambda functions on arm64

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -22,7 +22,9 @@ env:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    # arm64のLambdaイメージをエミュレーションなしでビルドする。
+    # arm64標準ランナーはpublicリポジトリでは無料枠で使える
+    runs-on: ubuntu-24.04-arm
     strategy:
       # 1つのターゲットが失敗しても残りは反映させる
       fail-fast: false
@@ -75,16 +77,16 @@ jobs:
         with:
           context: apps/backend
           target: ${{ matrix.target }}
-          # CDKのPlatform.LINUX_AMD64と揃える
-          platforms: linux/amd64
+          # CDKのPlatform.LINUX_ARM64およびLambdaのArchitecture.ARM_64と揃える
+          platforms: linux/arm64
           push: true
           # 既定のprovenance attestationはOCI image indexを作り、Lambdaが受け付けない
           provenance: false
           tags: |
             ${{ steps.target.outputs.image_uri }}
             ${{ steps.target.outputs.moving_tag_uri }}
-          cache-from: type=gha,scope=backend-${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=backend-${{ matrix.target }},ignore-error=true
+          cache-from: type=gha,scope=backend-${{ matrix.target }}-arm64
+          cache-to: type=gha,mode=max,scope=backend-${{ matrix.target }}-arm64,ignore-error=true
 
       # 可変タグではなくSHAタグで更新し、どのコミットが動いているかを追えるようにする
       - name: Update Lambda

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -81,22 +81,25 @@ export class AppStack extends cdk.Stack {
 
     const backendPath = path.join(__dirname, "..", "..", "apps", "backend");
 
+    // イメージのplatformとFunctionのarchitectureは連動しない為、両方をarm64で揃える。
+    // 食い違うとデプロイしたイメージをLambdaが起動できない
+
     // web: Lambda Web Adapter + uvicorn(api-fn)
     const webImage = lambda.DockerImageCode.fromImageAsset(backendPath, {
       target: "web",
-      platform: Platform.LINUX_AMD64,
+      platform: Platform.LINUX_ARM64,
     });
 
     // chat: webにLangGraph / LangChainを追加した構成(chat-fn)。
     // RAG関連ライブラリはイメージサイズが大きくapi-fnのコールドスタートを長くする為、分離する
     const chatImage = lambda.DockerImageCode.fromImageAsset(backendPath, {
       target: "chat",
-      platform: Platform.LINUX_AMD64,
+      platform: Platform.LINUX_ARM64,
     });
     // worker: awslambdaricによる軽量ハンドラ構成(ingest-fn)
     const workerImage = lambda.DockerImageCode.fromImageAsset(backendPath, {
       target: "worker",
-      platform: Platform.LINUX_AMD64,
+      platform: Platform.LINUX_ARM64,
     });
 
     const openaiApiKeyParameter =
@@ -116,6 +119,7 @@ export class AppStack extends cdk.Stack {
     // 認証、一覧、presigned URL発行、取込開始のSQS送信
     this.apiFunction = new lambda.DockerImageFunction(this, "ApiFunction", {
       code: webImage,
+      architecture: lambda.Architecture.ARM_64,
       memorySize: 512,
       timeout: cdk.Duration.seconds(30),
       // X-Rayのセグメントを記録する。トレースは従量課金であり固定費は増えない(ADR-0001)
@@ -141,6 +145,7 @@ export class AppStack extends cdk.Stack {
     // LangGraph Self-RAGによるSSEストリーミングチャット
     this.chatFunction = new lambda.DockerImageFunction(this, "ChatFunction", {
       code: chatImage,
+      architecture: lambda.Architecture.ARM_64,
       memorySize: 1024,
       timeout: cdk.Duration.seconds(300),
       // Lambda自身のセグメントは記録する。アプリ内の計装のみ環境変数で止める(ADR-0014)
@@ -186,6 +191,7 @@ export class AppStack extends cdk.Stack {
       "IngestFunction",
       {
         code: workerImage,
+        architecture: lambda.Architecture.ARM_64,
         memorySize: 1024,
         // SQSの可視性タイムアウト900秒以内に収める
         timeout: cdk.Duration.seconds(600),

--- a/cdk/test/__snapshots__/app-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/app-stack.test.ts.snap
@@ -109,6 +109,9 @@ exports[`スナップショット 1`] = `
         "ApiFunctionServiceRole52B9747B",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "ImageUri": {
             "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:<ASSET_HASH>",
@@ -308,6 +311,9 @@ exports[`スナップショット 1`] = `
         "ChatFunctionServiceRole544D50A9",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "ImageUri": {
             "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:<ASSET_HASH>",
@@ -554,6 +560,9 @@ exports[`スナップショット 1`] = `
         "IngestFunctionServiceRole55EB4427",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "ImageUri": {
             "Fn::Sub": "\${AWS::AccountId}.dkr.ecr.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-\${AWS::AccountId}-\${AWS::Region}:<ASSET_HASH>",

--- a/cdk/test/app-stack.test.ts
+++ b/cdk/test/app-stack.test.ts
@@ -62,6 +62,13 @@ describe('Lambda', () => {
     }
   });
 
+  test('3関数ともarm64で実行される', () => {
+    const functions = template.findResources('AWS::Lambda::Function');
+    for (const fn of Object.values(functions)) {
+      expect(fn.Properties.Architectures).toEqual(['arm64']);
+    }
+  });
+
   test('api-fnは512MB/30秒でDataStackのリソース名を環境変数に持つ', () => {
     const [, fn] = findFunctionByServiceName('api');
     expect(fn.Properties.MemorySize).toBe(512);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,6 +196,8 @@ api-fnとchat-fnでは、HTTPサーバーであるFastAPIをそのままLambda�
 | chat | chat-fn | webに`chat`依存グループ(LangGraph / LangChain)を追加 |
 | worker | ingest-fn | Adapterなし。awslambdaric + `ingest`依存グループ(pypdf) |
 
+3つのFunctionはいずれもarm64で実行する。x86_64より実行時間の単価が安く、11章のコスト試算もこの単価を前提としている。CDKのイメージアセットとCIのビルドはどちらもlinux/arm64で作成し、Functionのアーキテクチャと一致させる。
+
 ### 5.2 api-fn
 
 REST APIを担当するFunctionである。次のAPIを提供する。


### PR DESCRIPTION
### 変更内容

- 3つのイメージアセットを`Platform.LINUX_ARM64`でビルドし、api-fn / chat-fn / ingest-fnへ`architecture: Architecture.ARM_64`を指定した
- deploy-backend.ymlを`ubuntu-24.04-arm`ランナーへ移し、`platforms: linux/arm64`でネイティブビルドする
- GitHub Actionsキャッシュのscopeへ`-arm64`を付け、amd64のキャッシュを引かないようにした
- Dockerfileは変更していない
- architecture.md 5.1へarm64で実行する旨を追記した

### 検証結果

- 3ターゲットをローカルで`linux/arm64`ビルドし、エミュレーション実行でPythonが`aarch64`、Lambda Web Adapterのバイナリが`e_machine=0xb7`のAArch64 ELF、`app.main` / langgraph+langchain / awslambdaric+pypdf のimportが通ることを確認した
- ベースイメージ3種がいずれもlinux/arm64のマニフェストを持つこと、uv.lockの94パッケージにaarch64ホイールを欠くものがないことを確認した
- `npm run typecheck`と`npx jest`が成功する。スナップショットの差分は`Architectures`追加の3箇所のみ
- `cdk deploy AppStack --exclusively`を実行済み。3関数とも`Architectures: arm64`、`State: Active`、`LastUpdateStatus: Successful`

### 注意事項

- DataStackは`alarmEmail`をコンテキストから受け取るため、指定せずにデプロイするとDLQアラームのSNSメール購読が削除される。そのため今回は`--exclusively`でAppStackに限定した
- ローカルのDocker Desktopはcontainerdイメージストアを使っており、buildxの既定のattestationによって成果物がOCI image indexになる。Lambdaはこれを受け付けないため、手元からのデプロイには`BUILDX_NO_DEFAULT_ATTESTATIONS=1`が必要になる。cdk/READMEへの手順追記は未対応
- アップロードから取込、チャットまでの動作確認と、切り替え前後のDuration比較は未実施

---

- feat(cdk,ci): run the Lambda functions on arm64
- docs: note that the Lambda functions run on arm64

Closes #55
