### PR TITLE
Rename repository references to serverless-rag-chat

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -103,7 +103,7 @@ aws cloudfront create-invalidation --distribution-id <DistributionId出力> --pa
 
 ## CI/CD (CiStack)
 
-CiStackはGitHub ActionsのOIDC IDプロバイダと、Actionsが引き受けるデプロイ用ロール`event-driven-rag-github-actions`を作る。権限はSPAの同期、CloudFrontのキャッシュ無効化、ECRへのプッシュ、Lambdaのイメージ更新、スタック出力の読み取りに限定している。ワークフローは`cdk deploy`を行わないため、CloudFormationの更新権限は持たせていない。
+CiStackはGitHub ActionsのOIDC IDプロバイダと、Actionsが引き受けるデプロイ用ロール`serverless-rag-chat-github-actions`を作る。権限はSPAの同期、CloudFrontのキャッシュ無効化、ECRへのプッシュ、Lambdaのイメージ更新、スタック出力の読み取りに限定している。ワークフローは`cdk deploy`を行わないため、CloudFormationの更新権限は持たせていない。
 
 ### GitHub側の設定
 

--- a/cdk/lib/ci-stack.ts
+++ b/cdk/lib/ci-stack.ts
@@ -15,14 +15,14 @@ const GITHUB_OIDC_AUDIENCE = "sts.amazonaws.com";
 // IDの確認: gh api /repos/<owner>/<repo> --jq '{id, owner_id: .owner.id}'
 const GITHUB_OWNER = "ma-sa-shi";
 const GITHUB_OWNER_ID = 265779122;
-const GITHUB_REPOSITORY_NAME = "event-driven-rag";
+const GITHUB_REPOSITORY_NAME = "serverless-rag-chat";
 const GITHUB_REPOSITORY_ID = 1304510072;
 const DEPLOY_BRANCH = "main";
 
 export const DEPLOY_SUBJECT = `repo:${GITHUB_OWNER}@${GITHUB_OWNER_ID}/${GITHUB_REPOSITORY_NAME}@${GITHUB_REPOSITORY_ID}:ref:refs/heads/${DEPLOY_BRANCH}`;
 
 // ワークフローがARNを組み立てられるよう物理名を固定する
-export const DEPLOY_ROLE_NAME = "event-driven-rag-github-actions";
+export const DEPLOY_ROLE_NAME = "serverless-rag-chat-github-actions";
 
 export interface CiStackProps extends cdk.StackProps {
   dataStack: DataStack;

--- a/cdk/test/__snapshots__/ci-stack.test.ts.snap
+++ b/cdk/test/__snapshots__/ci-stack.test.ts.snap
@@ -29,7 +29,7 @@ exports[`スナップショット 1`] = `
               "Condition": {
                 "StringEquals": {
                   "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-                  "token.actions.githubusercontent.com:sub": "repo:ma-sa-shi@265779122/event-driven-rag@1304510072:ref:refs/heads/main",
+                  "token.actions.githubusercontent.com:sub": "repo:ma-sa-shi@265779122/serverless-rag-chat@1304510072:ref:refs/heads/main",
                 },
               },
               "Effect": "Allow",
@@ -46,7 +46,7 @@ exports[`スナップショット 1`] = `
           "Version": "2012-10-17",
         },
         "Description": "GitHub Actions deploy role (SPA sync / Lambda image update)",
-        "RoleName": "event-driven-rag-github-actions",
+        "RoleName": "serverless-rag-chat-github-actions",
       },
       "Type": "AWS::IAM::Role",
     },

--- a/cdk/test/ci-stack.test.ts
+++ b/cdk/test/ci-stack.test.ts
@@ -94,7 +94,7 @@ describe('デプロイロールの信頼ポリシー', () => {
     // 2026-07-15以降に作成されたリポジトリはowner IDとrepository IDをsubに含む。
     // 旧形式のままだとAssumeRoleWithWebIdentityが失敗する
     expect(DEPLOY_SUBJECT).toBe(
-      'repo:ma-sa-shi@265779122/event-driven-rag@1304510072:ref:refs/heads/main',
+      'repo:ma-sa-shi@265779122/serverless-rag-chat@1304510072:ref:refs/heads/main',
     );
     expect(DEPLOY_SUBJECT).not.toContain('*');
   });

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
       context: apps/backend
       # Without this, docker compose builds the last stage (worker)
       target: web
-    image: event-driven-rag-backend
+    image: serverless-rag-chat-backend
     ports:
       - "8000:8000"
     healthcheck:


### PR DESCRIPTION
## 実装内容
リポジトリ名を event-driven-rag から serverless-rag-chat へ改名し、名前に依存する参照も変更した。

- cdk/lib/ci-stack.ts: OIDCのsubを組み立てるGITHUB_REPOSITORY_NAMEと、デプロイロールの物理名DEPLOY_ROLE_NAME
- cdk/test/ci-stack.test.tsとそのスナップショット: 上記への追従
- compose.yaml: ローカルビルドのイメージ名
- cdk/README.md: ロール名の記述

SSMパラメータ名/event-driven-rag/*とCognitoのdomainPrefixは旧名のまま残した。どちらもデプロイ済みで、変更するとSecureStringの手動再作成とHosted UIドメインの再作成が必要になる一方、外部から見える名前ではないためである。

## 検証結果

- npm run typecheckとnpx jestは89件全てパス。CiStackのスナップショットの差分はsubとRoleNameの2行のみ
- npx cdk diff CiStackで、差分がデプロイロールの置き換えと信頼ポリシーのsubに限られることを確認
- npx cdk deploy CiStack --exclusivelyを適用済み。aws iam get-roleで新ロールのsubが新リポジトリ名になっていること、および旧ロールが削除されたことを確認

## 注意事項

- SecretsのAWS_ROLE_ARNをarn:aws:iam::152055465977:role/serverless-rag-chat-github-actionsへ更新するまで、mainへのマージでデプロイワークフローが失敗する。マージ前に必ず更新する

chore: rename repository references to serverless-rag-chat

Closes #67