### PR TITLE
Show chunk excerpts in chat search results

### DIFF
--- a/apps/frontend/src/components/ChatProgress.css
+++ b/apps/frontend/src/components/ChatProgress.css
@@ -93,6 +93,12 @@
   }
 }
 
+.doc-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
 .doc-open {
   font: inherit;
   padding: 0;
@@ -110,8 +116,15 @@
 .doc-score {
   font-family: var(--mono);
   font-size: 13px;
-  margin-left: 8px;
   opacity: 0.8;
+}
+
+.doc-excerpt {
+  margin: 2px 0 0;
+  font-size: 13px;
+  color: var(--text);
+  opacity: 0.75;
+  word-break: break-word;
 }
 
 .answer-body {

--- a/apps/frontend/src/components/ChatProgress.tsx
+++ b/apps/frontend/src/components/ChatProgress.tsx
@@ -34,6 +34,17 @@ const scoreFormatter = new Intl.NumberFormat("ja-JP", {
   maximumFractionDigits: 2,
 });
 
+// チャンクは500文字（apps/backend/app/ingest/chunking.py）あり全文は長すぎる為、
+// 同じファイル名のチャンクを見分けられる程度の長さだけ見せる
+const EXCERPT_LENGTH = 120;
+
+function excerpt(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length > EXCERPT_LENGTH
+    ? `${trimmed.slice(0, EXCERPT_LENGTH)}…`
+    : trimmed;
+}
+
 interface ChatProgressProps {
   attempts: Attempt[];
   isStreaming: boolean;
@@ -137,11 +148,16 @@ function renderDetail(attempt: Attempt, key: StepKey, options: DetailOptions) {
       <ul className="step-detail">
         {attempt.documents.map((document, index) => (
           <li key={index}>
-            {renderDocumentName(document, options.onOpenDocument)}
-            {document.score !== null && (
-              <span className="doc-score">
-                {scoreFormatter.format(document.score)}
-              </span>
+            <div className="doc-header">
+              {renderDocumentName(document, options.onOpenDocument)}
+              {document.score !== null && (
+                <span className="doc-score">
+                  {scoreFormatter.format(document.score)}
+                </span>
+              )}
+            </div>
+            {document.text && (
+              <p className="doc-excerpt">{excerpt(document.text)}</p>
             )}
           </li>
         ))}

--- a/apps/frontend/test/components/ChatProgress.test.tsx
+++ b/apps/frontend/test/components/ChatProgress.test.tsx
@@ -89,4 +89,22 @@ describe("ChatProgress", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText("orphan.pdf")).toBeInTheDocument();
   });
+
+  it("チャンク本文は120文字を超えると省略記号を付けて切り詰める", () => {
+    const short = "短い本文";
+    const long = "あ".repeat(130);
+    const attempts: Attempt[] = [
+      {
+        documents: [
+          retrieved({ filename: "short.pdf", text: short }),
+          retrieved({ filename: "long.pdf", text: long }),
+        ],
+      },
+    ];
+
+    render(<ChatProgress attempts={attempts} isStreaming={false} />);
+
+    expect(screen.getByText(short)).toBeInTheDocument();
+    expect(screen.getByText(`${"あ".repeat(120)}…`)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Show chunk excerpts in chat search results

### 実装内容

検索結果の各行がファイル名とスコアだけで、rerankされたチャンクの本文を示していなかった。同じファイルが異なるスコアで複数回並ぶと、利用者はどのチャンクが回答の根拠になったのか判断できなかった。既存の`text`フィールド（最大500文字）を120文字まで切り詰めて抜粋として表示するようにした。

- `apps/frontend/src/components/ChatProgress.tsx`に抜粋を切り詰める`excerpt()`を追加し、ファイル名・スコアの行と抜粋の行を分けて描画する
- `apps/frontend/src/components/ChatProgress.css`へ`.doc-header`と`.doc-excerpt`のスタイルを追加する

`npm test`、`npm run lint`、`npm run build`がいずれも成功する。追加したテストが保証するのは、120文字以内の本文はそのまま表示され、超過分は120文字で切り詰めて省略記号が付くことの2点である。

---

- feat(frontend): show chunk excerpts in chat search results

Closes #77 