### PR TITLE
Replace the demo video so captions clear the seek bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## デモ
 
-https://github.com/user-attachments/assets/56f11482-2021-4cf4-a797-dfd3518fe7d7
+https://github.com/user-attachments/assets/281f1c77-528e-4e81-9cb9-13ff9673abb9
 
 サインイン、ドキュメントのアップロードと取込、チャットでの質問、回答の根拠ドキュメントの確認、プロフィールでの履歴確認までの一連の流れ。
 


### PR DESCRIPTION
### 実装内容

- README.md: デモ動画の URL を、テロップを上にずらした動画の attachment URL に差し替えた。旧動画はテロップが画面の下端にあり、プレイヤーのシークバーと重なっていた。

### 検証結果

- 新しい URL が mp4（`content-type=video/mp4`）を返すことを確認した
- 動画は 1920×1080・30fps のまま 9.33MB に圧縮しており、無料プランの動画の上限（10MB）に収まる
- 実際に動画を再生し、シークバーとテロップが重ならないことを目視確認した

### 注意事項

- 動画ファイルはリポジトリに置かず、attachment URL で配信する。この方式への切り替えは 4778278 で main に反映済みで、本PRは動画の差し替えだけを行う

---

- docs: replace the demo video so captions clear the seek bar

Closes #81
