### PR TITLE
Rename the app to Knowledge Chat in the UI

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Event Driven RAG</title>
+    <title>Knowledge Chat</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/src/components/Layout.tsx
+++ b/apps/frontend/src/components/Layout.tsx
@@ -16,7 +16,7 @@ export function Layout() {
     <div className="layout">
       <header className="layout-header">
         <div className="layout-header-inner">
-          <span className="layout-brand">Event Driven RAG</span>
+          <span className="layout-brand">Knowledge Chat</span>
           <nav className="layout-nav">
             <NavLink to="/" end>
               チャット


### PR DESCRIPTION
### 実装内容

- `Layout.tsx`：ヘッダーのロゴ文字を Knowledge Chat に変更した
- `index.html`：ページタイトルを Knowledge Chat に変更した

フロントエンドのテスト（`npm test`）とPrettierのチェックが通ることを確認した。

---

- feat(frontend): rename the app to Knowledge Chat in the UI

Closes #85
